### PR TITLE
Add logging verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ devel:
 	cargo build -v -p proc
 
 	# Move plugin binaries
+	rm -rf target/debug/sys
 	mkdir -p target/debug/sys
 	mv target/debug/proc target/debug/sys/
 
@@ -21,6 +22,7 @@ build:
 	cargo build -p proc --release
 
 	# Move plugin binaries
+	rm -rf target/release/sys
 	mkdir -p target/release/sys
 	mv target/release/proc target/release/sys/
 

--- a/examples/models/router/entities/processes.cfg
+++ b/examples/models/router/entities/processes.cfg
@@ -4,13 +4,14 @@ entities:
     descr: static system configuration
     facts:
       default:
-        - label:
+        - devices:
             storage:
               type: SSD
               size: 2TB
               free: 500Mb
             mem:
               free: 10Mb
+        - network:
 
   logging:
     descr: Logging subsystem
@@ -38,7 +39,7 @@ entities:
     facts:
       default:
         - label:
-          path: /lib/systemd/systemd-resolved
+            path: /lib/systemd/systemd-resolved
 
   syslogd:
     descr: syslog daemon process

--- a/src/clidef.rs
+++ b/src/clidef.rs
@@ -60,8 +60,8 @@ pub fn cli(version: &'static str) -> Command {
             Arg::new("debug")
                 .short('d')
                 .long("debug")
-                .action(ArgAction::SetTrue)
-                .help("Set debug mode for more verbose output."),
+                .action(ArgAction::Count)
+                .help("Set debug mode for more verbose output. Increase this flag for more verbosity."),
         )
         .arg(
             Arg::new("help")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
+use clap::ArgMatches;
 use colored::Colorize;
 use libsysinspect::{
     intp::actproc::response::ActionResponse,
     logger,
     reactor::{evtproc::EventProcessor, handlers},
 };
+use log::LevelFilter;
 use std::env;
 
 mod clidef;
@@ -55,9 +57,13 @@ fn main() {
     }
 
     // Setup logger
-    if let Err(err) = log::set_logger(&LOGGER)
-        .map(|()| log::set_max_level(if params.get_flag("debug") { log::LevelFilter::Trace } else { log::LevelFilter::Info }))
-    {
+    if let Err(err) = log::set_logger(&LOGGER).map(|()| {
+        log::set_max_level(match params.get_count("debug") {
+            0 => LevelFilter::Info,
+            1 => LevelFilter::Debug,
+            2.. => LevelFilter::max(),
+        })
+    }) {
         return println!("{}", err);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use clap::ArgMatches;
 use colored::Colorize;
 use libsysinspect::{
     intp::actproc::response::ActionResponse,


### PR DESCRIPTION
This PR allows split `-d` for debug mode and `-dd` for trace mode.