### PR TITLE
Implement module sample mode

### DIFF
--- a/docs/moddev/modstruct.rst
+++ b/docs/moddev/modstruct.rst
@@ -164,12 +164,29 @@ Below are currently supported and required sections and attributes:
 ``returns``
 ^^^^^^^^^^^
 
-    Description in a free form what additional data might be returned in ``data`` section of the :ref:`formatting-response`. It has two sections to describe the return data type in details.
+    This section is mainly used to define return data structure and it is also used as a help sample.
+    The following syntax is used:
 
-    ``description``
+    .. code-block:: text
+        :caption: Synopsis of return data structure definition
 
-        A multiline description what the data type is all about. Type ``String``, **required**.
+        returns:
+            <option|argument|$>:
+                :description: |
+                    Multiline text
+                <structure>
 
-    ``example``
+    From the described synopsis above:
 
-        An actual multiline example of a returned data type in a JSON format. Type ``String``, **required**.
+    - ``option`` or ``argument`` or ``$`` is the sections what is returned in case these options are specified.
+      The ``$`` symbol means "no options specified" or *the default* state.
+
+    - ``:description`` is an internal field, used for a prefixed help section in the manual output.
+    - ``<structure>`` is any YAML-compliant structure that will be then converted to JSON and displayed as a sample.
+      Refer to the existing modules source code to see that in action.
+
+    .. important::
+
+        From the synopsis, the fied ``:description`` is prefixed with ``:`` (colon) symbol. The colon symbol marks
+        a field as "internal". These fields *do not belong* to the defined ``<structure>`` and will be excluded
+        from the final output.

--- a/modules/sys/net/src/mod_doc.yaml
+++ b/modules/sys/net/src/mod_doc.yaml
@@ -25,23 +25,28 @@ examples:
       }
 
 returns:
-  description: "Route information example"
-  example: |
-    "route-table":
-      [
-        { "gateway": "192.168.1.1", "mask": "0" },
-        {
-          "dst": "169.254.0.0",
-          "mask": "16",
-          "proto": "boot",
-          "scope": "link",
-        },
-        {
-          "dst": "192.168.2.0",
-          "if": "eth0",
-          "mask": "24",
-          "proto": "kernel",
-          "scope": "link",
-          "src": "192.168.1.123",
-        },
-      ]
+  route-table:
+    :description: "Returns network routing table (sample)."
+    retcode: 0
+    message: "Network data obtained"
+    data:
+      route-table:
+        - gateway: "192.168.1.1"
+          mask: "0"
+        - dst: "192.168.2.0"
+          if: "eth0"
+          mask: "24"
+          proto: "kernel"
+          scope: "link"
+          src: "192.168.1.123"
+
+  if-up:
+    :description: "Returns the list of all available network devices (sample)."
+    retcode: 0
+    message: "Network data obtained"
+    data:
+      if-up:
+        lo:
+          - mac: "00:00:00:00:00:00"
+          - IPv4: "127.0.0.1"
+            port: 0

--- a/modules/sys/proc/src/mod_doc.yaml
+++ b/modules/sys/proc/src/mod_doc.yaml
@@ -41,16 +41,19 @@ examples:
 
 # Description of additional data format
 returns:
-  description: |
-    Returns tabular data of "limits" and "cmd" containing an actual command line.
+  limits:
+    :description: |
+      Returns tabular data of "limits" and "cmd" containing an actual command line.
 
-  example: |
-    {
-      "limits": [
-          ["attribute", "soft", "hard", "units"],
-          ["cpu time", -1, -1, "seconds"],
-          ["processes", 126599, 126599, "processes"],
-          ["open files", 1024, 524288, "files"],
-        ],
-      "cmd": "/lib/systemd/systemd-logind",
-    },
+    limits:
+      - [attribute, soft, hard, units]
+      - [cpu time, -1, -1, seconds]
+      - [processes, 126599, 126599, processes]
+      - [open files, 1024, 524288, files]
+    cmd: /lib/systemd/systemd-logind
+
+  pid:
+    :description: |
+      Includes a PID of the process.
+
+    pid: 12345

--- a/modules/sys/run/src/mod_doc.yaml
+++ b/modules/sys/run/src/mod_doc.yaml
@@ -42,11 +42,19 @@ examples:
 
 # Description of additional data format
 returns:
-  description: |
-    Returns just a regular text of the command STDOUT.
-    NOTE: if "disown" flag is specified, no data is returned.
+  # Output data structure as a sample
+  # Happens by default
+  $:
+    :description: |
+      Returns just a regular text of the command STDOUT.
+    retcode: 0
+    message: "'uname -p' finished"
+    data:
+      stdout: "x86_64"
 
-  example: |
-    {
-      "stdout": "..."
-    },
+  # Happens when "disown" flag is specified
+  disown:
+    :description: |
+      No data block is returned for background processes
+    retcode: 0
+    message: "'uname -p' left running on a background"


### PR DESCRIPTION
Allows to generate help module samples from an actual defined data structure instead of making all that manually.

Resolves #21 issue.