### PR TITLE
Add support for dynamic templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,8 +549,31 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "pure-rust-locales",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -788,6 +821,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
 name = "digest"
@@ -1110,6 +1149,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.6.0",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1308,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "hyper"
@@ -1504,6 +1576,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "impl-more"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1781,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "sysinfo 0.32.0",
+ "tera",
  "textwrap",
  "tokio",
  "unicode-segmentation",
@@ -2067,6 +2156,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2248,44 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2298,6 +2434,12 @@ dependencies = [
  "chrono",
  "hex",
 ]
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
 
 [[package]]
 name = "quote"
@@ -2714,6 +2856,7 @@ version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -2803,6 +2946,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +2974,16 @@ dependencies = [
  "libc",
  "log",
  "parking_lot 0.11.2",
+]
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3051,6 +3210,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tera"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "globwalk",
+ "humansize",
+ "lazy_static",
+ "percent-encoding",
+ "pest",
+ "pest_derive",
+ "rand",
+ "regex",
+ "serde",
+ "serde_json",
+ "slug",
+ "unic-segment",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,6 +3432,56 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
+dependencies = [
+ "unic-ucd-segment",
+]
+
+[[package]]
+name = "unic-ucd-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/examples/models/router/entities/ports.cfg
+++ b/examples/models/router/entities/ports.cfg
@@ -46,6 +46,8 @@ entities:
             wifi: wlp0s20f3
 
   addresses:
+    # Any (common, i.e. $)
+    # "claims" is a reserved word.
     claims:
       # Fact label. It is referred
       # by a constraint, if needed
@@ -54,7 +56,11 @@ entities:
             if: virbr1
             mac: "52:54:00:36:8D:71"
             ipv4: "192.168.100.1"
+          {% if traits.system.os.name == "Ubuntu" %}
             port: 0
+          {% else %}
+            port: 1
+          {% endif %}
 
       $:
         - wifi-v6:

--- a/libsysinspect/Cargo.toml
+++ b/libsysinspect/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0.128"
 serde_yaml = "0.9.34"
 sha2 = "0.10.8"
 sysinfo = { version = "0.32.0", features = ["linux-tmpfs"] }
+tera = { version = "1.20.0", features = ["preserve_order", "date-locale"] }
 textwrap = { version = "0.16.1", features = ["hyphenation", "terminal_size"] }
 tokio = { version = "1.41.1", features = ["full"] }
 unicode-segmentation = "1.12.0"

--- a/libsysinspect/src/inspector.rs
+++ b/libsysinspect/src/inspector.rs
@@ -2,6 +2,7 @@ use crate::{
     intp::{self, inspector::SysInspector},
     mdescr::mspec,
     reactor::evtproc::EventProcessor,
+    traits::systraits::SystemTraits,
 };
 use intp::actproc::response::ActionResponse;
 
@@ -13,6 +14,9 @@ pub struct SysInspectRunner {
 
     // Check book labels
     cb_labels: Vec<String>,
+
+    // Minion traits, if running in distributed mode
+    traits: Option<SystemTraits>,
 }
 
 impl SysInspectRunner {
@@ -42,7 +46,7 @@ impl SysInspectRunner {
 
     pub fn start(&self) {
         log::info!("Starting sysinspect runner");
-        match mspec::load(&self.model_pth) {
+        match mspec::load(&self.model_pth, self.traits.clone()) {
             Ok(spec) => {
                 log::debug!("Initalising inspector");
                 match SysInspector::new(spec) {
@@ -82,5 +86,9 @@ impl SysInspectRunner {
             }
             Err(err) => log::error!("Error loading mspec: {}", err),
         };
+    }
+
+    pub fn set_traits(&mut self, traits: SystemTraits) {
+        self.traits = Some(traits);
     }
 }

--- a/libsysinspect/src/lib.rs
+++ b/libsysinspect/src/lib.rs
@@ -16,6 +16,7 @@ pub mod modlib;
 pub mod proto;
 pub mod reactor;
 pub mod rsa;
+pub mod tmpl;
 pub mod traits;
 pub mod util;
 
@@ -37,6 +38,7 @@ pub enum SysinspectError {
     FFINullError(NulError),
     DynError(Box<dyn Error>),
     AsynDynError(Box<dyn Error + Send + Sync>),
+    TemplateError(tera::Error),
 }
 
 impl Error for SysinspectError {
@@ -66,6 +68,7 @@ impl Display for SysinspectError {
             SysinspectError::ProtoError(err) => format!("(Protocol) {err}"),
             SysinspectError::DynError(err) => format!("(General) {err}"),
             SysinspectError::AsynDynError(err) => format!("(General part) {err}"),
+            SysinspectError::TemplateError(err) => format!("(DSL) {err}"),
         };
 
         write!(f, "{msg}")?;
@@ -111,5 +114,11 @@ impl From<Box<dyn Error>> for SysinspectError {
 impl From<Box<dyn Error + Send + Sync>> for SysinspectError {
     fn from(err: Box<dyn Error + Send + Sync>) -> SysinspectError {
         SysinspectError::DynError(err)
+    }
+}
+
+impl From<tera::Error> for SysinspectError {
+    fn from(err: tera::Error) -> Self {
+        SysinspectError::TemplateError(err)
     }
 }

--- a/libsysinspect/src/mdescr/mspec.rs
+++ b/libsysinspect/src/mdescr/mspec.rs
@@ -1,11 +1,5 @@
 use super::{datapatch, mspecdef::ModelSpec};
-use crate::{
-    cfg::select_config,
-    tmpl::render::ModelTplRender,
-    traits::{self, systraits::SystemTraits},
-    SysinspectError,
-};
-use serde_json::json;
+use crate::{cfg::select_config, tmpl::render::ModelTplRender, traits::systraits::SystemTraits, SysinspectError};
 use serde_yaml::Value;
 use std::{
     collections::HashMap,

--- a/libsysinspect/src/mdescr/mspec.rs
+++ b/libsysinspect/src/mdescr/mspec.rs
@@ -1,7 +1,14 @@
 use super::{datapatch, mspecdef::ModelSpec};
-use crate::{cfg::select_config, SysinspectError};
+use crate::{
+    cfg::select_config,
+    tmpl::render::ModelTplRender,
+    traits::{self, systraits::SystemTraits},
+    SysinspectError,
+};
+use serde_json::json;
 use serde_yaml::Value;
 use std::{
+    collections::HashMap,
     fs::{self},
     path::{Path, PathBuf},
 };
@@ -16,12 +23,26 @@ struct SpecLoader {
 
     // Only one init allowed
     init: bool,
+
+    // System traits if running in distributed mode
+    traits: Option<HashMap<String, serde_json::Value>>,
 }
 
 impl SpecLoader {
     // Constructor
-    fn new(pth: PathBuf) -> Self {
-        Self { pth, init: false }
+    fn new(pth: PathBuf, traits: Option<SystemTraits>) -> Self {
+        let mut ext: Option<HashMap<String, serde_json::Value>> = None;
+        if let Some(traits) = traits {
+            let mut et: HashMap<String, serde_json::Value> = HashMap::new();
+            for k in traits.items() {
+                if let Some(v) = traits.get(&k) {
+                    et.insert(k, v);
+                }
+            }
+            ext = Some(et);
+        }
+
+        Self { pth, init: false, traits: ext }
     }
 
     /// Collect YAML parts of the model from a different files
@@ -48,8 +69,13 @@ impl SpecLoader {
                         out.insert(0, serde_yaml::from_str::<Value>(&fs::read_to_string(etr.path())?)?);
                     }
                 } else if fname != MODEL_INDEX {
-                    // Get YAML chunks
-                    match serde_yaml::from_str::<Value>(&fs::read_to_string(etr.path())?) {
+                    // Get YAML chunks and render them
+                    let mut mtr = ModelTplRender::new(fname, &fs::read_to_string(etr.path())?);
+                    if let Some(traits) = self.traits.clone() {
+                        mtr.set_ns_values("traits", traits);
+                    }
+
+                    match serde_yaml::from_str::<Value>(&mtr.render()?) {
                         Ok(chunk) => out.push(chunk),
                         Err(err) => return Err(SysinspectError::ModelDSLError(format!("Unable to parse {fname}: {err}"))),
                     }
@@ -133,6 +159,6 @@ impl SpecLoader {
 }
 
 /// Load spec from a given path
-pub fn load(path: &str) -> Result<ModelSpec, SysinspectError> {
-    SpecLoader::new(fs::canonicalize(path)?).load()
+pub fn load(path: &str, traits: Option<SystemTraits>) -> Result<ModelSpec, SysinspectError> {
+    SpecLoader::new(fs::canonicalize(path)?, traits).load()
 }

--- a/libsysinspect/src/tmpl/mod.rs
+++ b/libsysinspect/src/tmpl/mod.rs
@@ -1,0 +1,1 @@
+pub mod render;

--- a/libsysinspect/src/tmpl/render.rs
+++ b/libsysinspect/src/tmpl/render.rs
@@ -1,0 +1,135 @@
+use colored::Colorize;
+use serde_json::{Map, Value};
+use std::{collections::HashMap, error::Error};
+use tera::{Context, Tera};
+
+use crate::SysinspectError;
+
+/// Renderer for the model templates.
+///
+/// It is using Tera Templates as an engine,
+/// similar to Jinja Templates from Django.
+/// The model render is designed to use once
+/// per a source.
+#[derive(Debug, Default)]
+pub struct ModelTplRender {
+    name: String,
+    src: String,
+    ctx: Context,
+    tpl: Tera,
+    res: Option<String>,
+}
+impl ModelTplRender {
+    pub fn new(name: &str, src: &str) -> Self {
+        Self { name: name.to_string(), src: src.to_string(), ..Default::default() }
+    }
+
+    /// Normalise namespace. No namespace can be a part of other namespace.
+    /// For example if there is "system.os.name", then "system.os" is offending namespace.
+    /// All namespaces must be completely unique.
+    fn normalise_ns(&self, m: &HashMap<String, Value>) -> Vec<String> {
+        let mut keys = m.keys().map(|s| s.to_string()).collect::<Vec<String>>();
+        keys.sort();
+
+        let mut bogus = Vec::new();
+        for (i, s) in keys.iter().enumerate() {
+            if let Some(next_s) = keys.get(i + 1) {
+                if next_s.starts_with(s) {
+                    bogus.push(s.clone());
+                }
+            }
+        }
+        bogus
+    }
+
+    fn namespace_exposer(&self, input: HashMap<String, Value>) -> Value {
+        let bogus = self.normalise_ns(&input);
+        let mut root = serde_json::Map::new();
+
+        for (key, value) in input {
+            if bogus.contains(&key) {
+                log::warn!("Skipping bogus namespace: {}", key.bright_yellow().bold());
+                continue;
+            }
+
+            let parts: Vec<&str> = key.split('.').collect();
+            let mut current = &mut root;
+
+            for (i, part) in parts.iter().enumerate() {
+                if i == parts.len() - 1 {
+                    current.insert(part.to_string(), value.clone());
+                } else {
+                    current = current
+                        .entry(part.to_string())
+                        .or_insert_with(|| Value::Object(serde_json::Map::new()))
+                        .as_object_mut()
+                        .expect("Duplicated namespace keys. This should not happen!");
+                }
+            }
+        }
+
+        Value::Object(root)
+    }
+
+    /// Cleans the source for the further processing, removing
+    /// empty lines, comments etc.
+    fn flatten_src(&self, dst: &str) -> String {
+        let mut out: Vec<String> = Vec::default();
+        for l in dst.lines() {
+            let cl = l.trim();
+            if cl.starts_with("#") || cl.is_empty() {
+                continue;
+            }
+            out.push(l.trim_end().to_string());
+        }
+        out.join("\n")
+    }
+
+    /// Set namespaced values so they can be accessed in the template by a namespace.
+    /// For example:
+    ///
+    /// ```text
+    ///     {% if mystuff.somebody.name == "Toto" %}
+    /// ```
+    ///
+    /// Namespaces are created from key of a hashmap and the value
+    /// is just a JSON. Example:
+    ///
+    /// ```rust
+    ///     let mut data = HashMap::new();
+    ///     data.insert("somebody.name", json!("Toto"));
+    /// ```
+    ///
+    /// Then register this HashMap as `mystuff`, passed to the `objname` arg.
+    pub fn set_ns_values(&mut self, objname: &str, v: HashMap<String, Value>) {
+        self.ctx.insert(objname, &self.namespace_exposer(v));
+    }
+
+    /// Set direct value to be accessed in the template directly.
+    pub fn set_value(&mut self, objname: &str, v: Value) {
+        self.ctx.insert(objname, &v);
+    }
+
+    pub fn render(&mut self) -> Result<String, SysinspectError> {
+        // Render only once
+        if let Some(res) = self.res.clone() {
+            return Ok(res);
+        }
+
+        self.tpl.add_raw_template(&self.name, &self.src)?;
+
+        let r = match self.tpl.render(&self.name, &self.ctx) {
+            Ok(r) => r,
+            Err(err) => {
+                let mut iem = String::new();
+                if let Some(err) = err.source() {
+                    iem = err.to_string();
+                }
+                return Err(SysinspectError::ModelDSLError(format!("{err}: {iem}")));
+            }
+        };
+
+        self.res = Some(self.flatten_src(&r));
+        Ok(self.res.clone().unwrap_or_default())
+    }
+}

--- a/libsysinspect/src/tmpl/render.rs
+++ b/libsysinspect/src/tmpl/render.rs
@@ -1,9 +1,8 @@
+use crate::SysinspectError;
 use colored::Colorize;
-use serde_json::{Map, Value};
+use serde_json::Value;
 use std::{collections::HashMap, error::Error};
 use tera::{Context, Tera};
-
-use crate::SysinspectError;
 
 /// Renderer for the model templates.
 ///

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -446,9 +446,6 @@ pub async fn minion(cfp: &str, fingerprint: Option<String>) -> Result<(), Sysins
     let minion = SysMinion::new(cfp, fingerprint).await?;
     minion.as_ptr().do_proto().await?;
 
-    // Example downloading file
-    //minion.as_ptr().download_file("models/inherited/model.cfg".to_string()).await;
-
     // Messages
     if minion.fingerprint.is_some() {
         minion.as_ptr().send_registration(minion.kman.get_pubkey_pem()).await?;

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -368,7 +368,10 @@ impl SysMinion {
         sr.set_state(mqr_l.state());
         sr.set_entities(mqr_l.entities());
         sr.set_checkbook_labels(mqr_l.checkbook_labels());
+        sr.set_traits(get_minion_traits());
+
         sr.start();
+
         log::debug!("Sysinspect model cycle finished");
     }
 


### PR DESCRIPTION
This PR allows to select parts of the model by minion traits as follows:

```jinja
{% if traits.system.os.name == "Ubuntu" %}
   typos: 6
   correct: "Debian"
{% else %}
   typos: 0
{% endif %}
```