### PR TITLE
Enable traits for all Python modules within the minion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,21 +373,20 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7c2840b66236045acd2607d5866e274380afd87ef99d6226e961e2cb47df45"
+checksum = "f47bb8cc16b669d267eeccf585aea077d0882f4777b1c1f740217885d6e6e5a3"
 dependencies = [
  "aws-lc-sys",
- "mirai-annotations",
  "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3a619a9de81e1d7de1f1186dcba4506ed661a0e483d84410fdef0ee87b2f96"
+checksum = "a2101df3813227bbaaaa0b04cd61c534c7954b22bd68d399b440be937dc63ff7"
 dependencies = [
  "bindgen",
  "cc",
@@ -570,9 +569,9 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "bytestring"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d80203ea6b29df88012294f62733de21cfeab47f17b41af3a38bc30a03ee72"
+checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
 dependencies = [
  "bytes",
 ]
@@ -1432,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -1851,7 +1850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -2141,9 +2140,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "local-channel"
@@ -2346,12 +2345,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "mt19937"
@@ -3331,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4861,9 +4854,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -5374,9 +5367,9 @@ checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -5386,9 +5379,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5419,18 +5412,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/libsysinspect/src/pylang/pvm.rs
+++ b/libsysinspect/src/pylang/pvm.rs
@@ -19,7 +19,7 @@ use std::{
     sync::Arc,
 };
 
-// use super::pylib::pysystem::syscore;
+use super::pylib::pysystem::syscore;
 
 pub struct PyVm {
     itp: Interpreter,
@@ -37,7 +37,7 @@ impl PyVm {
             .init_stdlib()
             .settings(cfg)
             .init_hook(Box::new(|vm| {
-                //vm.add_native_module("syscore".to_owned(), Box::new(syscore::make_module));
+                vm.add_native_module("syscore".to_owned(), Box::new(syscore::make_module));
             }))
             .interpreter();
 

--- a/libsysinspect/src/pylang/pylib/pysystem.rs
+++ b/libsysinspect/src/pylang/pylib/pysystem.rs
@@ -6,10 +6,12 @@ use rustpython_vm::pymodule;
 
 #[pymodule]
 pub mod syscore {
-    use crate::{cfg::mmconf::MinionConfig, traits::systraits::SystemTraits, util::dataconv};
+    use crate::{
+        traits::{self, systraits::SystemTraits},
+        util::dataconv,
+    };
     use rustpython_vm::PyResult;
     use rustpython_vm::{builtins::PyList, convert::ToPyObject, pyclass, PyObjectRef, PyPayload, VirtualMachine};
-    use std::path::PathBuf;
 
     #[derive(Debug, Clone)]
     struct StrVec(Vec<String>);
@@ -30,20 +32,7 @@ pub mod syscore {
     #[pyclass]
     impl MinionTraits {
         fn new() -> MinionTraits {
-            // This sucks big time. It always initialises traits for every script call
-            let cfg = match MinionConfig::new(PathBuf::from("/etc/sysinspect/sysinspect.conf")) {
-                Ok(c) => Some(c),
-                Err(err) => {
-                    log::debug!("Error initialising traits: {err}");
-                    None
-                }
-            };
-
-            if let Some(cfg) = cfg {
-                return MinionTraits { traits: Some(SystemTraits::new(cfg)) };
-            }
-
-            MinionTraits { ..Default::default() }
+            MinionTraits { traits: Some(traits::get_minion_traits(None)) }
         }
 
         #[pymethod]

--- a/libsysinspect/src/traits/mod.rs
+++ b/libsysinspect/src/traits/mod.rs
@@ -2,7 +2,8 @@ pub mod systraits;
 
 use std::collections::HashMap;
 
-use crate::SysinspectError;
+use crate::{cfg::mmconf::MinionConfig, SysinspectError};
+use once_cell::sync::OnceCell;
 use pest::Parser;
 use pest_derive::Parser;
 use serde_json::Value;
@@ -94,4 +95,16 @@ pub fn matches_traits(qt: Vec<Vec<HashMap<String, Value>>>, traits: SystemTraits
     }
 
     or_op_c.contains(&true)
+}
+
+/// System traits instance
+static _TRAITS: OnceCell<SystemTraits> = OnceCell::new();
+
+/// Returns a copy of initialised traits.
+pub fn get_minion_traits(cfg: Option<&MinionConfig>) -> SystemTraits {
+    if let Some(cfg) = cfg {
+        return _TRAITS.get_or_init(|| SystemTraits::new(cfg.clone())).to_owned();
+    }
+
+    _TRAITS.get_or_init(|| SystemTraits::new(MinionConfig::default())).to_owned()
 }

--- a/sysminion/src/proto.rs
+++ b/sysminion/src/proto.rs
@@ -1,5 +1,5 @@
 pub mod msg {
-    use crate::minion::{get_minion_traits, MINION_SID};
+    use crate::minion::MINION_SID;
     use libsysinspect::{
         proto::{rqtypes::RequestType, MinionMessage},
         traits,
@@ -13,7 +13,7 @@ pub mod msg {
     /// Make pong message
     pub fn get_pong() -> Vec<u8> {
         let p = MinionMessage::new(
-            dataconv::as_str(get_minion_traits(None).get(traits::SYS_ID)),
+            dataconv::as_str(traits::get_minion_traits(None).get(traits::SYS_ID)),
             RequestType::Pong,
             MINION_SID.to_string(),
         );

--- a/sysminion/src/proto.rs
+++ b/sysminion/src/proto.rs
@@ -13,7 +13,7 @@ pub mod msg {
     /// Make pong message
     pub fn get_pong() -> Vec<u8> {
         let p = MinionMessage::new(
-            dataconv::as_str(get_minion_traits().get(traits::SYS_ID)),
+            dataconv::as_str(get_minion_traits(None).get(traits::SYS_ID)),
             RequestType::Pong,
             MINION_SID.to_string(),
         );


### PR DESCRIPTION
Traits are now enabled to all minions, initialised only once at minion boot time.