### PR TITLE
machine id relocated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,6 +2112,7 @@ dependencies = [
  "textwrap 0.16.1",
  "tokio",
  "unicode-segmentation",
+ "uuid",
  "walkdir",
 ]
 

--- a/docs/global_config.rst
+++ b/docs/global_config.rst
@@ -169,6 +169,26 @@ and contains the following directives:
     and writable directories are limited to only a few. In this case *root* must be
     set according to the system setup.
 
+``id.path``
+
+    By default, the minion Id is the ``/etc/machine-id``. However, this file is usually
+    present on a regular Linux server and desktop distributions, but practically never
+    on the embedded systems. For this reason, the alternative location of the ``machine-id``
+    needs to be specified. On many embedded Linux systems and Android, usually ``/etc`` is
+    read-only, and very few places are allowed to be written.
+
+    This option takes one of the following:
+
+    - An absolute path to an existing ``machine-id`` file
+    - ``relative`` keyword, so it is ``$MINION_ROOT/machine-id``, which is ``/etc/sysinspect/machine-id``
+      by default.
+
+    .. code-block:: yaml
+
+        id.path: </absolute/path>|relative
+
+
+
 ``master.ip``
 
     Corresponds to ``bind.ip`` of Master node and should be identical.

--- a/libsysinspect/Cargo.toml
+++ b/libsysinspect/Cargo.toml
@@ -32,4 +32,5 @@ tera = { version = "1.20.0", features = ["preserve_order", "date-locale"] }
 textwrap = { version = "0.16.1", features = ["hyphenation", "terminal_size"] }
 tokio = { version = "1.41.1", features = ["full"] }
 unicode-segmentation = "1.12.0"
+uuid = { version = "1.11.0", features = ["v4"] }
 walkdir = "2.5.0"

--- a/libsysinspect/src/cfg/mmconf.rs
+++ b/libsysinspect/src/cfg/mmconf.rs
@@ -45,6 +45,9 @@ pub struct MinionConfig {
     /// Port of Master's fileserver. Default: 4201
     #[serde(rename = "master.fileserver.port")]
     master_fileserver_port: Option<u32>,
+
+    #[serde(rename = "id.path")]
+    machine_id: Option<String>,
 }
 
 impl MinionConfig {
@@ -88,6 +91,19 @@ impl MinionConfig {
     /// Get root directory for drop-in traits
     pub fn traits_dir(&self) -> PathBuf {
         self.root_dir().join(CFG_TRAITS_ROOT)
+    }
+
+    /// Return machine Id path
+    pub fn machine_id_path(&self) -> PathBuf {
+        if let Some(mid) = self.machine_id.clone() {
+            if mid.eq("relative") {
+                return self.root_dir().join("machine-id");
+            } else {
+                return PathBuf::from(mid);
+            }
+        }
+
+        PathBuf::from("/etc/machine-id")
     }
 }
 

--- a/libsysinspect/src/traits/systraits.rs
+++ b/libsysinspect/src/traits/systraits.rs
@@ -13,7 +13,6 @@ use std::{
     collections::HashMap,
     fs::{self},
     os::unix::fs::PermissionsExt,
-    path::PathBuf,
     process::Command,
 };
 
@@ -125,10 +124,9 @@ impl SystemTraits {
         self.put(SYS_OS_DISTRO.to_string(), json!(sysinfo::System::distribution_id()));
 
         // Machine Id (not always there)
-        let mip = PathBuf::from("/etc/machine-id");
         let mut mid = String::default();
-        if mip.exists() {
-            if let Ok(id) = fs::read_to_string(mip) {
+        if self.cfg.machine_id_path().exists() {
+            if let Ok(id) = fs::read_to_string(self.cfg.machine_id_path()) {
                 mid = id.trim().to_string();
             }
         }

--- a/libsysinspect/src/util/mod.rs
+++ b/libsysinspect/src/util/mod.rs
@@ -1,2 +1,27 @@
 pub mod dataconv;
 pub mod iofs;
+
+use crate::SysinspectError;
+use std::{fs, io, path::PathBuf};
+use uuid::Uuid;
+
+/// The `/etc/machine-id` is not always present, especially
+/// on the custom embedded systems. However, this file is used
+/// to identify a minion.
+///
+/// Write the `/etc/machine-id` (or other location), if not any yet.
+pub fn write_machine_id(p: Option<PathBuf>) -> Result<(), SysinspectError> {
+    let p = p.unwrap_or(PathBuf::from("/etc/machine-id"));
+    if !p.exists() {
+        if let Err(err) = fs::write(p, Uuid::new_v4().to_string().replace("-", "")) {
+            return Err(SysinspectError::IoErr(err));
+        }
+    } else {
+        return Err(SysinspectError::IoErr(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("File \"{}\" already exists", p.to_str().unwrap_or_default()),
+        )));
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use libsysinspect::{
     logger,
     reactor::handlers,
     traits::get_minion_traits,
-    util, SysinspectError,
+    SysinspectError,
 };
 use log::LevelFilter;
 use std::{env, fs::OpenOptions, io::Write};

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use libsysinspect::{
     logger,
     reactor::handlers,
     traits::get_minion_traits,
-    SysinspectError,
+    util, SysinspectError,
 };
 use log::LevelFilter;
 use std::{env, fs::OpenOptions, io::Write};

--- a/sysinspect.conf
+++ b/sysinspect.conf
@@ -27,5 +27,6 @@ config:
     # Root directory where minion keeps all data.
     # Default: /etc/sysinspect — same as for master
     root: /etc/sysinspect
+    id.path: relative
     master.ip: 192.168.2.31
     master.port: 4200


### PR DESCRIPTION
Embedded systems do not have `/etc/machine-id` (usually).