### PR TITLE
Add bridge module for the integration with Ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/_build
 man/*8
 package/
 .tmp/
+/vendor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "ascii"
@@ -708,18 +708,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1406,7 +1406,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http 1.2.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1511,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -1527,7 +1527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -1574,7 +1574,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body",
  "httparse",
  "itoa",
@@ -1591,7 +1591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1626,7 +1626,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -3174,7 +3174,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4191,7 +4191,7 @@ name = "sysinspect"
 version = "0.2.0"
 dependencies = [
  "chrono",
- "clap 4.5.21",
+ "clap 4.5.22",
  "colored",
  "libsysinspect",
  "log",
@@ -4204,7 +4204,7 @@ name = "sysmaster"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "clap 4.5.21",
+ "clap 4.5.22",
  "colored",
  "ed25519-dalek",
  "futures",
@@ -4228,7 +4228,7 @@ dependencies = [
 name = "sysminion"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.21",
+ "clap 4.5.22",
  "colored",
  "ed25519-dalek",
  "glob",
@@ -4426,9 +4426,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -4447,9 +4447,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4497,9 +4497,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4547,9 +4547,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5363,9 +5363,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
+checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
 
 [[package]]
 name = "yoke"

--- a/libsysinspect/Cargo.toml
+++ b/libsysinspect/Cargo.toml
@@ -20,8 +20,9 @@ prettytable-rs = "0.10.0"
 rand = "0.8.5"
 regex = "1.10.6"
 rsa = { version = "0.9.6", features = ["pkcs5", "sha1", "sha2"] }
-rustpython = { version = "0.4.0", features = ["freeze-stdlib"] }
+#rustpython = { path = "../../RustPython", features = ["freeze-stdlib"] }
 rustpython-pylib = { version = "0.4.0", features = ["freeze-stdlib"] }
+rustpython = { version = "0.4.0", features = ["freeze-stdlib"] }
 rustpython-vm = { version = "0.4.0", features = ["freeze-stdlib"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"

--- a/libsysinspect/src/cfg/mod.rs
+++ b/libsysinspect/src/cfg/mod.rs
@@ -5,7 +5,9 @@ Config reader
 pub mod mmconf;
 
 use crate::SysinspectError;
+use mmconf::MinionConfig;
 use nix::unistd::Uid;
+use once_cell::sync::OnceCell;
 use std::{env, path::PathBuf};
 
 pub const APP_CONF: &str = "sysinspect.conf";
@@ -13,7 +15,7 @@ pub const APP_DOTCONF: &str = ".sysinspect";
 pub const APP_HOME: &str = "/etc/sysinspect";
 
 /// Select app conf
-pub fn select_config(p: Option<&str>) -> Result<PathBuf, SysinspectError> {
+pub fn select_config_path(p: Option<&str>) -> Result<PathBuf, SysinspectError> {
     // Override path from options
     if let Some(ovrp) = p {
         let ovrp = PathBuf::from(ovrp);
@@ -51,4 +53,12 @@ pub fn select_config(p: Option<&str>) -> Result<PathBuf, SysinspectError> {
     }
 
     Err(SysinspectError::ConfigError("No config has been found".to_string()))
+}
+
+/// Minion Confinguration
+static _MINION_CFG: OnceCell<MinionConfig> = OnceCell::new();
+
+/// Returns a copy of initialised traits.
+pub fn get_minion_config(p: Option<&str>) -> Result<MinionConfig, SysinspectError> {
+    Ok(_MINION_CFG.get_or_try_init(|| MinionConfig::new(select_config_path(p)?))?.to_owned())
 }

--- a/libsysinspect/src/mdescr/mspec.rs
+++ b/libsysinspect/src/mdescr/mspec.rs
@@ -1,5 +1,5 @@
 use super::{datapatch, mspecdef::ModelSpec};
-use crate::{cfg::select_config, tmpl::render::ModelTplRender, traits::systraits::SystemTraits, SysinspectError};
+use crate::{cfg::select_config_path, tmpl::render::ModelTplRender, traits::systraits::SystemTraits, SysinspectError};
 use serde_yaml::Value;
 use std::{
     collections::HashMap,
@@ -141,7 +141,7 @@ impl SpecLoader {
         }
 
         // Load app config and merge to the main model
-        base.push(serde_yaml::from_str::<Value>(&fs::read_to_string(select_config(None)?)?)?);
+        base.push(serde_yaml::from_str::<Value>(&fs::read_to_string(select_config_path(None)?)?)?);
 
         let mut base = self.merge_parts(&mut base)?;
         if !iht.is_empty() {

--- a/libsysinspect/src/reactor/receiver.rs
+++ b/libsysinspect/src/reactor/receiver.rs
@@ -18,7 +18,7 @@ impl Receiver {
     ///   `eid` - Entity Id
     ///   `response` - ActionResponse object
     pub fn register(&mut self, eid: String, response: ActionResponse) {
-        log::trace!("Registered action response: {:#?}", response);
+        log::debug!("Registered action response: {:#?}", response);
         self.actions.insert(eid, response);
 
         // XXX: And process here as well!

--- a/libsysinspect/src/traits/mod.rs
+++ b/libsysinspect/src/traits/mod.rs
@@ -97,7 +97,10 @@ pub fn matches_traits(qt: Vec<Vec<HashMap<String, Value>>>, traits: SystemTraits
     or_op_c.contains(&true)
 }
 
-/// System traits instance
+/// System traits instance. Traits are system properties and attributes
+/// on which a minion is running.
+///
+/// P.S. These are not Rust traits. :-)
 static _TRAITS: OnceCell<SystemTraits> = OnceCell::new();
 
 /// Returns a copy of initialised traits.

--- a/modules/cfg/README.md
+++ b/modules/cfg/README.md
@@ -1,0 +1,3 @@
+# Ansible Integration
+
+The `cfg.mgmt` module implements Ansible integration.

--- a/modules/cfg/bridge.py
+++ b/modules/cfg/bridge.py
@@ -1,0 +1,98 @@
+from ast import mod
+from importlib.machinery import ModuleSpec
+import ansible
+import json
+import sys
+import importlib.util
+
+from types import ModuleType
+from io import StringIO, BytesIO
+from contextlib import redirect_stdout
+from sysinspect import SysinspectReturn
+from syscore import AnsibleBridge
+
+
+class StdinWrapper:
+    """
+    A wrapper to add a 'buffer' attribute to BytesIO for compatibility with Ansible.
+    """
+
+    def __init__(self, data):
+        self._buffer = BytesIO(data)
+
+    @property
+    def buffer(self):
+        return self._buffer
+
+    def read(self, *args, **kwargs):
+        return self._buffer.read(*args, **kwargs)
+
+    def readline(self, *args, **kwargs):
+        return self._buffer.readline(*args, **kwargs)
+
+    def __iter__(self):
+        return iter(self._buffer)
+
+    def close(self):
+        self._buffer.close()
+
+
+def invoke_ansible_module(module_path, args):
+    """
+    Call an Ansible module
+    """
+    spec: ModuleSpec | None = importlib.util.spec_from_file_location(
+        "ansible_module", module_path
+    )
+    if spec is None:
+        return "{}"
+
+    module = importlib.util.module_from_spec(spec)
+
+    # Inject a fake __main__ context
+    main = ModuleType("__main__")
+    main.__dict__.update(
+        {"__file__": module_path, "__name__": "__main__", "sys": sys, "json": json}
+    )
+    sys.modules["__main__"] = main
+
+    spec.loader.exec_module(module)
+    sys.stdin = StdinWrapper(json.dumps({"ANSIBLE_MODULE_ARGS": args}).encode("utf-8"))
+
+    if getattr(module, "main", None) is None:
+        raise Exception("Action modules are not supported")
+
+    output = StringIO()
+    try:
+        with redirect_stdout(output):
+            module.main()
+    except SystemExit as e:
+        if e.code != 0:
+            return {"error": f"Module exited with error code: {e.code}"}
+    except Exception as e:
+        return {"error": f"Module exception: {e}"}
+
+    return json.loads(output.getvalue())
+
+
+def main(*opts, **args) -> str:
+    """
+    Main function to dispatch the module.
+    """
+
+    if not opts:
+        return str(
+            SysinspectReturn(retcode=1, message="Target Ansible module not specified")
+        )
+
+    bridge = AnsibleBridge()
+    modpath = bridge.builtin_path(opts[0][0])
+
+    try:
+        return str(
+            SysinspectReturn().add_data(
+                {"ansible": invoke_ansible_module(modpath, args)}
+            )
+        )
+    except Exception as e:
+        return str(SysinspectReturn(retcode=1, message=str(e)))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::ArgMatches;
 use colored::Colorize;
 use libsysinspect::{
-    cfg::{mmconf::MasterConfig, select_config},
+    cfg::{mmconf::MasterConfig, select_config_path},
     inspector::SysInspectRunner,
     logger,
     reactor::handlers,
@@ -50,7 +50,7 @@ fn set_logger(p: &ArgMatches) {
 
 /// Get configuration of the master
 fn get_cfg(p: &ArgMatches) -> Result<MasterConfig, SysinspectError> {
-    MasterConfig::new(select_config(p.get_one::<&str>("config").cloned())?)
+    MasterConfig::new(select_config_path(p.get_one::<&str>("config").cloned())?)
 }
 
 fn main() {

--- a/sysmaster/src/main.rs
+++ b/sysmaster/src/main.rs
@@ -6,7 +6,7 @@ mod rmt;
 
 use clidef::cli;
 use libsysinspect::{
-    cfg::{mmconf::MasterConfig, select_config},
+    cfg::{mmconf::MasterConfig, select_config_path},
     logger, SysinspectError,
 };
 use log::LevelFilter;
@@ -49,7 +49,7 @@ async fn main() -> Result<(), SysinspectError> {
     // Get config
     let mut cfp = PathBuf::from(params.get_one::<String>("config").unwrap_or(&"".to_string()).to_owned());
     if !cfp.exists() {
-        cfp = match select_config(None) {
+        cfp = match select_config_path(None) {
             Ok(cfp) => {
                 log::debug!("Reading config at {}", cfp.to_str().unwrap_or_default());
                 cfp

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -250,7 +250,7 @@ impl SysMaster {
                                     let mut guard = c_master.lock().await;
                                     guard.session.ping(&c_id, &c_payload);
                                     let uptime = guard.session.uptime(req.id()).unwrap_or_default();
-                                    log::debug!(
+                                    log::trace!(
                                         "Update last contacted for {} (alive for {:.2} min)",
                                         req.id().to_string(),
                                         uptime as f64 / 60.0
@@ -307,7 +307,7 @@ impl SysMaster {
                                 line = lines.next_line() => {
                                     match line {
                                         Ok(Some(payload)) => {
-                                            log::info!("Querying minions: {}", payload);
+                                            log::debug!("Querying minions: {}", payload);
                                             if let Some(msg) = master.lock().await.msg_query(&payload) {
                                                 let _ = bcast.send(msg.sendable().unwrap());
                                             }

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -24,26 +24,6 @@ use uuid::Uuid;
 
 /// Session Id of the minion
 pub static MINION_SID: Lazy<String> = Lazy::new(|| Uuid::new_v4().to_string());
-/*
-Traits are system properties and attributes on which a minion is running.
-
-P.S. These are not Rust traits. :-)
- */
-
-/*
-/// System traits instance
-static _TRAITS: OnceCell<SystemTraits> = OnceCell::new();
-
-/// Returns a copy of initialised traits.
-pub fn traits::get_minion_traits(cfg: Option<&MinionConfig>) -> SystemTraits {
-    if let Some(cfg) = cfg {
-        return _TRAITS.get_or_init(|| SystemTraits::new(cfg.clone())).to_owned();
-    }
-
-    _TRAITS.get_or_init(|| SystemTraits::new(MinionConfig::default())).to_owned()
-}
-    */
-
 pub struct SysMinion {
     cfg: MinionConfig,
     fingerprint: Option<String>,

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -1,6 +1,6 @@
 use crate::{filedata::MinionFiledata, proto, rsa::MinionRSAKeyManager};
 use libsysinspect::{
-    cfg::{self, mmconf::MinionConfig},
+    cfg::{get_minion_config, mmconf::MinionConfig},
     inspector::SysInspectRunner,
     proto::{
         errcodes::ProtoErrorCode,
@@ -37,9 +37,7 @@ pub struct SysMinion {
 
 impl SysMinion {
     pub async fn new(cfp: &str, fingerprint: Option<String>) -> Result<Arc<SysMinion>, SysinspectError> {
-        let cfp = cfg::select_config(Some(cfp))?;
-
-        let cfg = MinionConfig::new(cfp)?;
+        let cfg = get_minion_config(Some(cfp))?;
         let (rstm, wstm) = TcpStream::connect(cfg.master()).await.unwrap().into_split();
         let instance = SysMinion {
             cfg: cfg.clone(),


### PR DESCRIPTION
This adds a minimal integration with Ansible via `cfg.bridge` module. Key points:

- Ansible should be installed as a library on the client machine
- No support for action modules, only standalone (with `main()` function inside)
- It is slow as Python... 😉 

Usage is pretty straightforward in actions:

```yaml
actions:
  module: cfg.bridge
  state:
    my_state:
      opts:
        # Ansible module
        - copy
      args:
        src: /etc/networks
        dest: /tmp/networks.copy
        mode: 0400
```

This should basically call an Ansible module `copy` and copy `/etc/networks` as `/tmp/networks.copy` destination.