### PR TITLE
Add fs.file infochecks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "users",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,11 +1160,13 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 name = "file"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "libsysinspect",
  "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
+ "users",
 ]
 
 [[package]]
@@ -4954,6 +4956,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/docs/moddescr/fs_file.rst
+++ b/docs/moddescr/fs_file.rst
@@ -24,6 +24,9 @@ The following options are available:
   ``delete``
     Delete a specified file
 
+  ``info``
+    Get file information
+
 
 The following arguments to the options are available:
 
@@ -90,3 +93,25 @@ Returns just a regular text of the command STDOUT. If fill specified:
           "changed": true
         }
       }
+
+File information has extensive additional fields in ``data`` section. Example:
+
+.. code-block:: json
+
+  "data": {
+    "changed": true,
+    "path": "/etc/passwd",
+    "type": "file",
+    "is_file": true,
+    "is_dir": false,
+    "size": 3442,
+    "created": "2023-11-14T15:59:13.966561943+00:00",
+    "modified": "2023-11-14T15:59:13.966561943+00:00",
+    "accessed": "2025-02-13T15:17:01.315542012+00:00",
+    "mode": "0644",
+    "uid": 0,
+    "gid": 0,
+    "user": "root",
+    "group": "root",
+    "sha256": "ee0582f813ee1b6f7623f01ce8fb7223d712d1847a0a46fb657f6f56620c64fa"
+  }

--- a/examples/models/cm/model.cfg
+++ b/examples/models/cm/model.cfg
@@ -31,6 +31,18 @@ actions:
           name: "claim(netconfig.name)"
           pull: "/networks"
 
+  info-netconfig:
+    descr: Display information about network cfg
+    module: fs.file
+    bind:
+      - file-ops
+    state:
+      $:
+        opts:
+          - info
+        args:
+          name: "claim(netconfig.name)"
+
   delete-netconfig:
     descr: Delete network cfg file
     module: fs.file

--- a/modules/fs/file/Cargo.toml
+++ b/modules/fs/file/Cargo.toml
@@ -10,4 +10,5 @@ reqwest = { version = "0.12.12", features = ["blocking"] }
 serde = "1.0.213"
 serde_json = "1.0.132"
 serde_yaml = "0.9.34"
+sha2 = "0.10.8"
 users = "0.11.0"

--- a/modules/fs/file/Cargo.toml
+++ b/modules/fs/file/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chrono = "0.4.39"
 libsysinspect = { path = "../../../libsysinspect" }
 reqwest = { version = "0.12.12", features = ["blocking"] }
 serde = "1.0.213"
 serde_json = "1.0.132"
 serde_yaml = "0.9.34"
+users = "0.11.0"

--- a/modules/fs/file/src/info.rs
+++ b/modules/fs/file/src/info.rs
@@ -1,0 +1,106 @@
+/*
+Informational functions
+ */
+
+use chrono::{DateTime, Utc};
+use libsysinspect::modlib::{
+    response::ModResponse,
+    runtime::{ArgValue, ModRequest},
+};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::time::SystemTime;
+use std::{fs, os::unix::fs::MetadataExt};
+use users::{get_group_by_gid, get_user_by_uid};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct FileMetadata {
+    ftype: String,
+    is_file: bool,
+    is_dir: bool,
+    size: u64,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    modified: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    accessed: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<String>,
+
+    uid: u32,
+    gid: u32,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    group: Option<String>,
+}
+
+/// Convert system time to ISO format
+fn time2iso(time: SystemTime) -> Option<String> {
+    let datetime: DateTime<Utc> = time.into();
+    Some(datetime.to_rfc3339())
+}
+
+fn mode_to_octal(mode: u32) -> String {
+    format!("{:04o}", mode & 0o7777)
+}
+
+/// Collect file information
+pub(crate) fn info(rq: &ModRequest, rsp: &mut ModResponse) {
+    rsp.set_retcode(0);
+
+    let p = PathBuf::from(rq.args().get("name").unwrap_or(&ArgValue::default()).as_string().unwrap_or_default());
+
+    let meta = match fs::metadata(p) {
+        Ok(m) => m,
+        Err(err) => {
+            rsp.set_retcode(1);
+            rsp.set_message(&format!("Error obtaining file data: {}", err));
+            return;
+        }
+    };
+
+    match serde_json::to_value(&FileMetadata {
+        ftype: if meta.is_file() {
+            "file".to_string()
+        } else if meta.is_dir() {
+            "directory".to_string()
+        } else {
+            "link".to_string()
+        },
+        is_file: meta.is_file(),
+        is_dir: meta.is_dir(),
+        size: meta.len(),
+        created: meta.created().ok().and_then(time2iso),
+        modified: meta.modified().ok().and_then(time2iso),
+        accessed: meta.accessed().ok().and_then(time2iso),
+        mode: Some(mode_to_octal(meta.mode())),
+        uid: meta.uid(),
+        gid: meta.gid(),
+        user: get_user_by_uid(meta.uid()).map(|i| i.name().to_string_lossy().into_owned()),
+        group: get_group_by_gid(meta.gid()).map(|i| i.name().to_string_lossy().into_owned()),
+    }) {
+        Ok(j) => {
+            if let Err(err) = rsp.set_data(j) {
+                rsp.set_retcode(1);
+                rsp.set_message(&format!("Error sending file data: {}", err));
+                return;
+            };
+        }
+        Err(err) => {
+            rsp.set_retcode(1);
+            rsp.set_message(&format!("Error getting file data: {}", err));
+            return;
+        }
+    };
+
+    rsp.set_message("Data is obtained");
+    _ = rsp.cm_set_changed(true);
+}

--- a/modules/fs/file/src/info.rs
+++ b/modules/fs/file/src/info.rs
@@ -101,6 +101,6 @@ pub(crate) fn info(rq: &ModRequest, rsp: &mut ModResponse) {
         }
     };
 
-    rsp.set_message("Data is obtained");
+    rsp.set_message(&format!("Data has been obtained"));
     _ = rsp.cm_set_changed(true);
 }

--- a/modules/fs/file/src/info.rs
+++ b/modules/fs/file/src/info.rs
@@ -15,7 +15,7 @@ use users::{get_group_by_gid, get_user_by_uid};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct FileMetadata {
-    #[serde(rename = "file")]
+    #[serde(rename = "path")]
     name: String,
 
     #[serde(rename = "type")]

--- a/modules/fs/file/src/info.rs
+++ b/modules/fs/file/src/info.rs
@@ -119,6 +119,6 @@ pub(crate) fn info(rq: &ModRequest, rsp: &mut ModResponse) {
         }
     };
 
-    rsp.set_message(&format!("Data has been obtained"));
+    rsp.set_message("Data has been obtained");
     _ = rsp.cm_set_changed(true);
 }

--- a/modules/fs/file/src/info.rs
+++ b/modules/fs/file/src/info.rs
@@ -15,6 +15,10 @@ use users::{get_group_by_gid, get_user_by_uid};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct FileMetadata {
+    #[serde(rename = "file")]
+    name: String,
+
+    #[serde(rename = "type")]
     ftype: String,
     is_file: bool,
     is_dir: bool,
@@ -58,7 +62,7 @@ pub(crate) fn info(rq: &ModRequest, rsp: &mut ModResponse) {
 
     let p = PathBuf::from(rq.args().get("name").unwrap_or(&ArgValue::default()).as_string().unwrap_or_default());
 
-    let meta = match fs::metadata(p) {
+    let meta = match fs::metadata(&p) {
         Ok(m) => m,
         Err(err) => {
             rsp.set_retcode(1);
@@ -68,6 +72,7 @@ pub(crate) fn info(rq: &ModRequest, rsp: &mut ModResponse) {
     };
 
     match serde_json::to_value(&FileMetadata {
+        name: p.to_str().unwrap_or_default().to_string(),
         ftype: if meta.is_file() {
             "file".to_string()
         } else if meta.is_dir() {

--- a/modules/fs/file/src/main.rs
+++ b/modules/fs/file/src/main.rs
@@ -1,5 +1,6 @@
 mod fdel;
 mod fill;
+mod info;
 
 use libsysinspect::{
     init_mod_doc,
@@ -37,6 +38,7 @@ fn run_mod(rq: &ModRequest) -> ModResponse {
     match rq.options().first().unwrap_or(&ArgValue::default()).as_string().unwrap_or_default().as_str() {
         "create" => fill::do_create(rq, &mut resp, strict),
         "delete" => fdel::do_delete(rq, &mut resp, strict),
+        "info" => info::info(rq, &mut resp),
         opt => {
             resp.set_message(&format!("Unknown option: {}", opt));
             return resp;

--- a/modules/fs/file/src/mod_doc.yaml
+++ b/modules/fs/file/src/mod_doc.yaml
@@ -11,6 +11,9 @@ options:
   - name: delete
     description: "Delete a specified file"
 
+  - name: info
+    description: "Get file information"
+
 # Keyword arguments
 arguments:
   - name: name


### PR DESCRIPTION
Adds `info` option to `fs.file` returning all information about a file or a directory.