### PR TITLE
Fix permission check and documentation typos

### DIFF
--- a/docs/modeldescr/entities.rst
+++ b/docs/modeldescr/entities.rst
@@ -14,7 +14,7 @@ call specific modules, and constraints that process them.
 
 .. important::
 
-   Entities the the following rules:
+   Entities follow the following rules:
 
    - An entity is independent of the specific architecture of a system
    - An entity may contain only self-applied claims, describing only that particular entity.
@@ -24,7 +24,7 @@ call specific modules, and constraints that process them.
 Synopsis
 --------
 
-Entitles describe claims and relations within the architecture. These expectations should
+Entities describe claims and relations within the architecture. These expectations should
 be aligned with constraints. Each entity has a **true** or **false** state. A "true" state is when
 all constraints and checks produce the expected result.
 

--- a/libsetup/src/mnsetup.rs
+++ b/libsetup/src/mnsetup.rs
@@ -50,7 +50,7 @@ impl MinionSetup {
     }
 
     fn check_my_permissions(&self) -> Result<(), SysinspectError> {
-        if unsafe { libc::getuid() } == 0 {
+        if unsafe { libc::getuid() } != 0 {
             return Err(SysinspectError::ConfigError("SysMinion must be run as root".to_string()));
         }
         Ok(())
@@ -96,13 +96,13 @@ impl MinionSetup {
         if self.alt_dir.is_empty() { "/var/run".to_string() } else { format!("{}/run", self.alt_dir) }
     }
 
-    /// Get /var/tmp
+    /// Get /var/tmp/sysinspect
     /// This is the directory where the temporary files are stored
     fn get_tmp(&self) -> String {
         if self.alt_dir.is_empty() { "/var/tmp/sysinspect".to_string() } else { format!("{}/tmp/db", self.alt_dir) }
     }
 
-    /// Get /var/tmp/db
+    /// Get /tmp
     /// This is the directory where the database files are stored
     fn get_db(&self) -> String {
         if self.alt_dir.is_empty() { "/tmp".to_string() } else { format!("{}/tmp", self.alt_dir) }

--- a/libsysinspect/tests/utl_dataconv.rs
+++ b/libsysinspect/tests/utl_dataconv.rs
@@ -9,7 +9,7 @@ mod dataconv_test {
         let m = serde_yaml::from_str::<HashMap<String, Value>>("foo: 1").unwrap();
         let v = m.get("foo").unwrap();
         let i = dataconv::as_int(Some(v).cloned());
-        assert!(i == 1);
+        assert_eq!(i, 1);
     }
 
     #[test]
@@ -52,7 +52,7 @@ mod dataconv_test {
         let v = m.get("foo").unwrap();
         let i = dataconv::as_int_opt(Some(v).cloned());
         assert!(i.is_some(), "Data must contain something");
-        assert!(i.unwrap_or(0) == 1, "Data must be 1");
+        assert_eq!(i.unwrap_or(0), 1, "Data must be 1");
     }
 
     #[test]
@@ -60,7 +60,7 @@ mod dataconv_test {
         let m = serde_yaml::from_str::<HashMap<String, Value>>("foo: \"bar,spam,baz,toto\"").unwrap();
         let v = m.get("foo").unwrap();
         let l = dataconv::as_str_list(Some(v).cloned());
-        assert!(l.len() == 4, "Data length must be 4");
+        assert_eq!(l.len(), 4, "Data length must be 4");
         assert!(
             l == vec!["bar".to_string(), "spam".to_string(), "baz".to_string(), "toto".to_string()],
             "Vector must be the same"
@@ -73,7 +73,7 @@ mod dataconv_test {
         let v = m.get("foo").unwrap();
         let l = dataconv::as_str_list_opt(Some(v).cloned());
         assert!(l.is_some(), "Data must contain something");
-        assert!(l.clone().unwrap().len() == 4, "Data length must be 4");
+        assert_eq!(l.clone().unwrap().len(), 4, "Data length must be 4");
         assert!(
             l.unwrap() == vec!["bar".to_string(), "spam".to_string(), "baz".to_string(), "toto".to_string()],
             "Vector must be the same"
@@ -87,6 +87,6 @@ mod dataconv_test {
         let s = dataconv::to_string(Some(v).cloned());
         assert!(s.is_some(), "Data must contain something");
         let s = s.unwrap();
-        assert!(s.eq("bar,spam,baz,toto"));
+        assert_eq!(s, "bar,spam,baz,toto");
     }
 }


### PR DESCRIPTION
## Summary
- correct root permission logic in `mnsetup`
- align documentation comments in `mnsetup`
- fix typos in the entity description docs
- use `assert_eq!` for clarity in data conversion tests

## Testing
- `cargo fmt --all` *(failed: unsuccessful tunnel)*
- `cargo test --quiet` *(failed: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68401ad8e174832e94fef1f9da54e746