### PR TITLE
Minion dev mode for modules

### DIFF
--- a/docs/genusage/cli.rst
+++ b/docs/genusage/cli.rst
@@ -63,7 +63,7 @@ Output should be something like this:
     [15/12/2024 21:47:03] - WARN: Preferred config at  does not exist, falling back
     [15/12/2024 21:47:03] - INFO: Initialising minion
     [15/12/2024 21:47:03] - INFO: Loading system traits data
-    [15/12/2024 21:47:04] - INFO: Lading network traits data
+    [15/12/2024 21:47:04] - INFO: Loading network traits data
     [15/12/2024 21:47:04] - INFO: Loading trait functions
     [15/12/2024 21:47:04] - INFO: Registration request to 10.10.2.75:4200
     [15/12/2024 21:47:04] - INFO: Minion registration has been accepted

--- a/docs/moddev/pymod.rst
+++ b/docs/moddev/pymod.rst
@@ -140,3 +140,41 @@ Python script like so:
         print(dir(cfg))
 
         return "{}"
+
+Running Python Modules Locally
+==============================
+
+To test your Python module locally, you can use the ``sysminion`` command. This is particularly useful for debugging and
+testing purposes. The ``sysminion`` command includes a special sub-command, ``module``, which allows you to invoke your
+modules directly:
+
+.. code-block:: shell
+
+    sysminion module --help
+
+Synopsis:
+
+.. code-block:: shell
+
+    Local module invocation
+
+    Usage: module [OPTIONS]
+
+    Options:
+    -n, --name <name>     Name of the module to invoke
+    -a, --args <args>     Key-value argument pairs to pass to the module (format: key=value)
+    -o, --opts <opts>...  Options to pass to the module (comma-separated)
+    -h, --help            Display help for this command
+
+Although this feature can launch any module, it is primarily designed for testing and debugging Python modules. These
+modules are executed by the Minion's embedded Python interpreter, which differs from the standard Python environment.
+
+Currently, the Minion cannot list all available modules. However, you can manually check the module files located in the
+`$ROOT/share/modules` directory. To list all available modules, you can use the ``sysinspect`` utility on a Master machine
+as follows:
+
+.. code-block:: shell
+
+    sysinspect module -L
+
+This command will display all available modules on the Master, which can be helpful for identifying what is accessible.

--- a/libsysinspect/src/cfg/mod.rs
+++ b/libsysinspect/src/cfg/mod.rs
@@ -18,12 +18,14 @@ pub const APP_HOME: &str = "/etc/sysinspect";
 pub fn select_config_path(p: Option<&str>) -> Result<PathBuf, SysinspectError> {
     // Override path from options
     if let Some(ovrp) = p {
-        let ovrp = PathBuf::from(ovrp);
-        if ovrp.exists() {
-            return Ok(ovrp);
-        }
+        if !ovrp.is_empty() {
+            let ovrp = PathBuf::from(ovrp);
+            if ovrp.exists() {
+                return Ok(ovrp);
+            }
 
-        log::warn!("Preferred config at {} does not exist, falling back", ovrp.to_str().unwrap_or_default());
+            log::warn!("Preferred config at {} does not exist, falling back", ovrp.to_str().unwrap_or_default());
+        }
     }
 
     // Current

--- a/libsysinspect/src/intp/actproc/modfinder.rs
+++ b/libsysinspect/src/intp/actproc/modfinder.rs
@@ -207,9 +207,8 @@ impl ModCall {
 
     /// Evaluate constraints
     fn eval_constraints(&self, ar: &ActionModResponse) -> ConstraintResponse {
-        fn eval<F>(
-            mc: &ModCall, cret: &mut ConstraintResponse, c: &Constraint, kind: ConstraintKind, eval_fn: F, ar: &ActionModResponse,
-        ) where
+        fn eval<F>(mc: &ModCall, cret: &mut ConstraintResponse, c: &Constraint, kind: ConstraintKind, eval_fn: F, ar: &ActionModResponse)
+        where
             F: Fn(&ModCall, &Constraint, &ActionModResponse) -> (Option<bool>, Option<Vec<String>>, Vec<ExprRes>),
         {
             let (res, msgs, expr) = eval_fn(mc, c, ar);
@@ -223,8 +222,7 @@ impl ModCall {
             }
         }
 
-        let mut cret =
-            ConstraintResponse::new(format!("{} with {}", self.aid, self.get_mod_ns().unwrap_or("(unknown)".to_string())));
+        let mut cret = ConstraintResponse::new(format!("{} with {}", self.aid, self.get_mod_ns().unwrap_or("(unknown)".to_string())));
         for c in &self.constraints {
             eval(self, &mut cret, c, ConstraintKind::All, Self::eval_cst_all, ar);
             eval(self, &mut cret, c, ConstraintKind::Any, Self::eval_cst_any, ar);
@@ -251,13 +249,11 @@ impl ModCall {
         let args = self.args.iter().map(|(k, v)| (k.to_string(), json!(v))).collect::<IndexMap<String, serde_json::Value>>();
 
         // TODO: Add libpath and modpath here! Must come from MinionConfig
-        match pylang::pvm::PyVm::new(
-            get_cfg_sharelib().join(DEFAULT_MODULES_LIB_DIR),
-            get_cfg_sharelib().join(DEFAULT_MODULES_DIR),
-        )
-        .as_ptr()
-        .call(&self.module, Some(opts), Some(args))
-        {
+        match pylang::pvm::PyVm::new(get_cfg_sharelib().join(DEFAULT_MODULES_LIB_DIR), get_cfg_sharelib().join(DEFAULT_MODULES_DIR)).as_ptr().call(
+            &self.module,
+            Some(opts),
+            Some(args),
+        ) {
             Ok(out) => match serde_json::from_str::<ActionModResponse>(&out) {
                 Ok(r) => Ok(Some(ActionResponse::new(
                     self.eid.to_owned(),

--- a/libsysinspect/src/intp/conf.rs
+++ b/libsysinspect/src/intp/conf.rs
@@ -90,21 +90,12 @@ impl Config {
     /// Get module (or Python module) from the namespace
     pub fn get_module(&self, namespace: &str) -> Result<PathBuf, SysinspectError> {
         // Fool-proof cleanup, likely a bad idea
+        // XXX: This is reimplemented in modfinder::ModCall::set_module_ns
         let mut modpath = self.modules.to_owned().unwrap_or(get_cfg_sharelib().join(DEFAULT_MODULES_DIR)).join(
-            namespace
-                .trim_start_matches('.')
-                .trim_end_matches('.')
-                .trim()
-                .split('.')
-                .map(|s| s.to_string())
-                .collect::<Vec<String>>()
-                .join("/"),
+            namespace.trim_start_matches('.').trim_end_matches('.').trim().split('.').map(|s| s.to_string()).collect::<Vec<String>>().join("/"),
         );
 
-        let pymodpath = modpath
-            .parent()
-            .unwrap()
-            .join(format!("{}.py", modpath.file_name().unwrap().to_os_string().to_str().unwrap_or_default()));
+        let pymodpath = modpath.parent().unwrap().join(format!("{}.py", modpath.file_name().unwrap().to_os_string().to_str().unwrap_or_default()));
 
         // Collision
         if pymodpath.exists() && modpath.exists() {

--- a/libsysinspect/src/pylang/pvm.rs
+++ b/libsysinspect/src/pylang/pvm.rs
@@ -60,6 +60,7 @@ impl PyVm {
     }
 
     fn load_pylib(&self, vm: &VirtualMachine) -> Result<(), SysinspectError> {
+        log::debug!("Loading Python library from {}", self.libpath);
         match vm.import("sys", 0) {
             Ok(sysmod) => match sysmod.get_attr("path", vm) {
                 Ok(syspath) => {

--- a/libsysinspect/src/pylang/pvm.rs
+++ b/libsysinspect/src/pylang/pvm.rs
@@ -2,17 +2,17 @@
 Python virtual machine
  */
 
-use crate::{pylang::PY_MAIN_FUNC, SysinspectError};
+use crate::{SysinspectError, pylang::PY_MAIN_FUNC};
 use colored::Colorize;
 use indexmap::IndexMap;
 use rustpython_vm::{
+    AsObject, PyResult,
     compiler::Mode::Exec,
     function::{FuncArgs, KwArgs},
-    AsObject, PyResult,
 };
 use rustpython_vm::{Interpreter, Settings};
 use rustpython_vm::{PyObjectRef, VirtualMachine};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -47,8 +47,7 @@ impl PyVm {
     /// Load main script of a module by a regular namespace
     fn load_by_ns(&self, ns: &str) -> Result<String, SysinspectError> {
         // XXX: util::get_namespace() ? Because something similar exists for the binaries
-        let pbuff = PathBuf::from(&self.modpath)
-            .join(format!("{}.py", ns.replace(".", "/").trim_start_matches("/").trim_end_matches("/")));
+        let pbuff = PathBuf::from(&self.modpath).join(format!("{}.py", ns.replace(".", "/").trim_start_matches("/").trim_end_matches("/")));
         self.load_by_path(&pbuff)
     }
 
@@ -100,10 +99,9 @@ impl PyVm {
                 }
             }
             Value::String(s) => vm.ctx.new_str(s).into(),
-            Value::Array(arr) => vm
-                .ctx
-                .new_list(arr.into_iter().map(|item| self.from_json(vm, item).expect("Failed to convert JSON")).collect())
-                .into(),
+            Value::Array(arr) => {
+                vm.ctx.new_list(arr.into_iter().map(|item| self.from_json(vm, item).expect("Failed to convert JSON")).collect()).into()
+            }
             Value::Object(obj) => {
                 let py_dict = vm.ctx.new_dict();
                 for (key, val) in obj {
@@ -165,10 +163,8 @@ impl PyVm {
                 py_args.set_item(py_key.as_object(), py_val, vm).unwrap();
             }
 
-            let kwargs: KwArgs = py_args
-                .into_iter()
-                .map(|(k, v)| (k.downcast::<rustpython_vm::builtins::PyStr>().unwrap().as_str().to_string(), v))
-                .collect();
+            let kwargs: KwArgs =
+                py_args.into_iter().map(|(k, v)| (k.downcast::<rustpython_vm::builtins::PyStr>().unwrap().as_str().to_string(), v)).collect();
 
             let fref = match scope.globals.get_item(PY_MAIN_FUNC, vm) {
                 Ok(fref) => fref,

--- a/libsysinspect/src/traits/systraits.rs
+++ b/libsysinspect/src/traits/systraits.rs
@@ -151,7 +151,7 @@ impl SystemTraits {
 
     /// Load network data
     fn get_network(&mut self) {
-        log::info!("Lading network traits data");
+        log::info!("Loading network traits data");
         let net = sysinfo::Networks::new_with_refreshed_list();
         for (ifs, data) in net.iter() {
             self.put(format!("system.net.{}.mac", ifs), json!(data.mac_address().to_string()));

--- a/python/modules/hello/example.py
+++ b/python/modules/hello/example.py
@@ -1,0 +1,36 @@
+from sysinspect import SysinspectReturn
+from syscore import MinionTraits
+import os
+
+def help() -> str:
+    return """
+Options:
+    traits - display all minion traits
+    help   - this help
+    ver    - Display version
+    """
+
+def main(args, **kw) -> str:
+    """
+    Main function to dispatch the module.
+    """
+
+    # Expand SysinspectReturn with your data.
+    # See lib/sysinspect.py for more details.
+    r = SysinspectReturn()
+
+    out = {}
+
+    if "help" in args:
+        print(help())
+        return str(r)
+
+    if "ver" in args:
+        print("Version 0.1")
+        return str(r)
+
+    if "traits" in args:
+        t = MinionTraits()
+        out.update(dict(map(lambda x:(x[0], x[1]), map(lambda k:(k, t.get(k)), t.list()))))
+
+    return str(r.add_data(out))

--- a/sysminion/src/clidef.rs
+++ b/sysminion/src/clidef.rs
@@ -59,6 +59,24 @@ pub fn cli(version: &'static str, appname: &'static str) -> Command {
             .arg(Arg::new("help").short('h').long("help").action(ArgAction::SetTrue).help("Display help on this command"))
         )
 
+        .subcommand(Command::new("module").about("Local module invocation").styles(styles.clone()).disable_help_flag(true)
+            .arg(Arg::new("name").short('n').long("name").help("Module name to invoke"))
+            .arg(Arg::new("args").short('a').long("args").action(ArgAction::Append).value_parser(clap::builder::ValueParser::new(|s: &str|
+                {
+                    let parts: Vec<&str> = s.splitn(2, '=').collect();
+                    if parts.len() == 2 {
+                        Ok((parts[0].to_string(), parts[1].to_string()))
+                    } else {
+                        Err(String::from("Key-value argument pair, translates to --key=value. Specify this pair multiple times for multiple pairs."))
+                    }
+                })).help("Key-value argument pairs to pass to the module (format: key=value)"))
+            .arg(Arg::new("opts").short('o').long("opts").num_args(1..).value_parser(clap::builder::ValueParser::new(|s: &str|
+                {
+                    Ok::<Vec<String>, String>(s.split(',').map(|item| item.trim().to_string()).collect())
+                })).help("Options to pass to the module (comma-separated)"))
+            .arg(Arg::new("help").short('h').long("help").action(ArgAction::SetTrue).help("Display help on this command"))
+        )
+
         // Other
         .next_help_heading("Other")
         .arg(

--- a/sysminion/src/main.rs
+++ b/sysminion/src/main.rs
@@ -166,7 +166,7 @@ async fn main() -> std::io::Result<()> {
             log::error!("Error running setup: {err}");
         }
     } else if let Some(sub) = params.subcommand_matches("module") {
-        if let Err(err) = minion::launch_module(get_config(&params), sub).await {
+        if let Err(err) = minion::launch_module(sub).await {
             log::error!("Error launching module: {err}");
         }
     } else {

--- a/sysminion/src/main.rs
+++ b/sysminion/src/main.rs
@@ -166,7 +166,7 @@ async fn main() -> std::io::Result<()> {
             log::error!("Error running setup: {err}");
         }
     } else if let Some(sub) = params.subcommand_matches("module") {
-        if let Err(err) = minion::launch_module(sub).await {
+        if let Err(err) = minion::launch_module(get_config(&params), sub).await {
             log::error!("Error launching module: {err}");
         }
     } else {

--- a/sysminion/src/main.rs
+++ b/sysminion/src/main.rs
@@ -85,8 +85,7 @@ fn help(cli: &mut Command, params: ArgMatches) -> bool {
     false
 }
 
-#[tokio::main]
-async fn main() -> std::io::Result<()> {
+fn main() -> std::io::Result<()> {
     let mut cli = cli(VERSION, APPNAME);
     if env::args().collect::<Vec<String>>().len() == 1 {
         cli.print_help()?;
@@ -166,7 +165,7 @@ async fn main() -> std::io::Result<()> {
             log::error!("Error running setup: {err}");
         }
     } else if let Some(sub) = params.subcommand_matches("module") {
-        if let Err(err) = minion::launch_module(get_config(&params), sub).await {
+        if let Err(err) = minion::launch_module(get_config(&params), sub) {
             log::error!("Error launching module: {err}");
         }
     } else {

--- a/sysminion/src/main.rs
+++ b/sysminion/src/main.rs
@@ -59,15 +59,18 @@ fn get_config(params: &ArgMatches) -> MinionConfig {
 
 // Print help?
 fn help(cli: &mut Command, params: ArgMatches) -> bool {
-    if let Some(sub) = params.subcommand_matches("setup") {
-        if sub.get_flag("help") {
-            if let Some(s_cli) = cli.find_subcommand_mut("setup") {
-                _ = s_cli.print_help();
-                return true;
+    for sc in ["setup", "module"] {
+        if let Some(sub) = params.subcommand_matches(sc) {
+            if sub.get_flag("help") {
+                if let Some(s_cli) = cli.find_subcommand_mut(sc) {
+                    _ = s_cli.print_help();
+                    return true;
+                }
+                return false;
             }
-            return false;
         }
     }
+
     if params.get_flag("help") {
         _ = &cli.print_long_help();
         return true;
@@ -123,10 +126,7 @@ fn main() -> std::io::Result<()> {
                 sout
             }
             Err(err) => {
-                log::error!(
-                    "Unable to create main log file at {}: {err}, terminating",
-                    cfg.logfile_std().to_str().unwrap_or_default()
-                );
+                log::error!("Unable to create main log file at {}: {err}, terminating", cfg.logfile_std().to_str().unwrap_or_default());
                 exit(1);
             }
         };
@@ -163,6 +163,10 @@ fn main() -> std::io::Result<()> {
     } else if let Some(sub) = params.subcommand_matches("setup") {
         if let Err(err) = minion::setup(sub) {
             log::error!("Error running setup: {err}");
+        }
+    } else if let Some(sub) = params.subcommand_matches("module") {
+        if let Err(err) = minion::launch_module(sub) {
+            log::error!("Error launching module: {err}");
         }
     } else {
         cli.print_help()?;

--- a/sysminion/src/main.rs
+++ b/sysminion/src/main.rs
@@ -85,7 +85,8 @@ fn help(cli: &mut Command, params: ArgMatches) -> bool {
     false
 }
 
-fn main() -> std::io::Result<()> {
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
     let mut cli = cli(VERSION, APPNAME);
     if env::args().collect::<Vec<String>>().len() == 1 {
         cli.print_help()?;
@@ -165,7 +166,7 @@ fn main() -> std::io::Result<()> {
             log::error!("Error running setup: {err}");
         }
     } else if let Some(sub) = params.subcommand_matches("module") {
-        if let Err(err) = minion::launch_module(sub) {
+        if let Err(err) = minion::launch_module(get_config(&params), sub).await {
             log::error!("Error launching module: {err}");
         }
     } else {

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use clap::ArgMatches;
 use colored::Colorize;
-use indexmap::IndexMap;
 use libmodpak::MODPAK_SYNC_STATE;
 use libsetup::get_ssh_client_ip;
 use libsysinspect::{
@@ -660,22 +659,30 @@ pub(crate) fn setup(args: &ArgMatches) -> Result<(), SysinspectError> {
 }
 
 /// Launch a module
-pub(crate) async fn launch_module(cfg: MinionConfig, args: &ArgMatches) -> Result<(), SysinspectError> {
+pub(crate) async fn launch_module(args: &ArgMatches) -> Result<(), SysinspectError> {
     let name = args.get_one::<String>("name").ok_or(SysinspectError::ConfigError("Module name is required".to_string()))?;
+    let mut modcaller = ModCall::default().set_module(PathBuf::from(name));
 
-    let kw: IndexMap<String, String> =
-        args.get_many::<(String, String)>("args").unwrap_or_default().map(|(key, value)| (key.clone(), value.clone())).collect();
-    let opts = args.get_many::<Vec<String>>("opts").unwrap_or_default().flatten().cloned().collect::<Vec<String>>();
-    let mut x = ModCall::default().set_module(PathBuf::from(name));
-    for (k, v) in &kw {
-        x.add_kwargs(k.to_string(), v.to_string());
+    for (k, v) in args
+        .get_many::<(String, String)>("args")
+        .unwrap_or_default()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<Vec<(String, String)>>()
+    {
+        modcaller.add_kwargs(k.to_string(), v.to_string());
     }
 
-    for o in opts {
-        x.add_opt(o);
+    for o in args.get_many::<Vec<String>>("opts").unwrap_or_default().flatten().cloned().collect::<Vec<String>>() {
+        modcaller.add_opt(o);
     }
 
-    println!("\n\nResult of {}:\n{}", name, KeyValueFormatter::new(x.run()?.unwrap_or_default().response.data().unwrap_or_default()).format());
+    let out = modcaller.run()?.unwrap_or_default().response.data().unwrap_or_default();
+    if !out.is_null() {
+        println!("\n\nResult of {}:\n{}", name, KeyValueFormatter::new(out).format());
+        return Ok(());
+    } else {
+        log::debug!("No data returned from the module {}", name);
+    }
 
     Ok(())
 }

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -33,6 +33,7 @@ use libsysinspect::{
 use once_cell::sync::Lazy;
 use serde_json::json;
 use std::{
+    collections::HashMap,
     fs,
     path::PathBuf,
     sync::Arc,
@@ -655,4 +656,19 @@ pub(crate) fn setup(args: &ArgMatches) -> Result<(), SysinspectError> {
     }
 
     libsetup::mnsetup::MinionSetup::new().set_config(get_minion_config(None)?).set_alt_dir(dir.to_str().unwrap_or_default().to_string()).setup()
+}
+
+/// Launch a module
+pub(crate) fn launch_module(args: &ArgMatches) -> Result<(), SysinspectError> {
+    let name = args.get_one::<String>("name").ok_or(SysinspectError::ConfigError("Module name is required".to_string()))?;
+
+    let kw: HashMap<String, String> =
+        args.get_many::<(String, String)>("args").unwrap_or_default().map(|(key, value)| (key.clone(), value.clone())).collect();
+    let opts = args.get_many::<Vec<String>>("opts").unwrap_or_default().flatten().cloned().collect::<Vec<String>>();
+
+    println!("Module name: {}", name);
+    println!("{:#?}", kw);
+    println!("{:#?}", opts);
+
+    Ok(())
 }

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -18,7 +18,11 @@ use libsysinspect::{
         mmconf::{DEFAULT_PORT, MinionConfig, SysInspectConfig},
     },
     inspector::SysInspectRunner,
-    intp::actproc::{modfinder::ModCall, response::ActionResponse},
+    intp::{
+        actproc::{modfinder::ModCall, response::ActionResponse},
+        inspector::SysInspector,
+    },
+    mdescr::mspecdef::ModelSpec,
     proto::{
         MasterMessage, MinionMessage, ProtoConversion,
         errcodes::ProtoErrorCode,
@@ -659,9 +663,10 @@ pub(crate) fn setup(args: &ArgMatches) -> Result<(), SysinspectError> {
 }
 
 /// Launch a module
-pub(crate) async fn launch_module(cfg: MinionConfig, args: &ArgMatches) -> Result<(), SysinspectError> {
+pub(crate) fn launch_module(cfg: MinionConfig, args: &ArgMatches) -> Result<(), SysinspectError> {
     let name = args.get_one::<String>("name").ok_or(SysinspectError::ConfigError("Module name is required".to_string()))?;
     let mut modcaller = ModCall::default().set_module_ns(name, cfg.sharelib_dir());
+    let _ = SysInspector::new(ModelSpec::default(), Some(cfg.sharelib_dir())); // That will fail (and it is OK), but it will set sharelib for the module caller
 
     for (k, v) in args
         .get_many::<(String, String)>("args")

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -659,9 +659,9 @@ pub(crate) fn setup(args: &ArgMatches) -> Result<(), SysinspectError> {
 }
 
 /// Launch a module
-pub(crate) async fn launch_module(args: &ArgMatches) -> Result<(), SysinspectError> {
+pub(crate) async fn launch_module(cfg: MinionConfig, args: &ArgMatches) -> Result<(), SysinspectError> {
     let name = args.get_one::<String>("name").ok_or(SysinspectError::ConfigError("Module name is required".to_string()))?;
-    let mut modcaller = ModCall::default().set_module(PathBuf::from(name));
+    let mut modcaller = ModCall::default().set_module_ns(name, cfg.sharelib_dir());
 
     for (k, v) in args
         .get_many::<(String, String)>("args")

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use clap::ArgMatches;
 use colored::Colorize;
+use indexmap::IndexMap;
 use libmodpak::MODPAK_SYNC_STATE;
 use libsetup::get_ssh_client_ip;
 use libsysinspect::{
@@ -18,7 +19,7 @@ use libsysinspect::{
         mmconf::{DEFAULT_PORT, MinionConfig, SysInspectConfig},
     },
     inspector::SysInspectRunner,
-    intp::actproc::response::ActionResponse,
+    intp::actproc::{modfinder::ModCall, response::ActionResponse},
     proto::{
         MasterMessage, MinionMessage, ProtoConversion,
         errcodes::ProtoErrorCode,
@@ -26,6 +27,7 @@ use libsysinspect::{
         query::{MinionQuery, SCHEME_COMMAND},
         rqtypes::RequestType,
     },
+    reactor::fmt::{formatter::StringFormatter, kvfmt::KeyValueFormatter},
     rsa,
     traits::{self},
     util::{self, dataconv},
@@ -33,7 +35,6 @@ use libsysinspect::{
 use once_cell::sync::Lazy;
 use serde_json::json;
 use std::{
-    collections::HashMap,
     fs,
     path::PathBuf,
     sync::Arc,

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -678,7 +678,7 @@ pub(crate) async fn launch_module(args: &ArgMatches) -> Result<(), SysinspectErr
 
     let out = modcaller.run()?.unwrap_or_default().response.data().unwrap_or_default();
     if !out.is_null() {
-        println!("\n\nResult of {}:\n{}", name, KeyValueFormatter::new(out).format());
+        println!("\n{}", KeyValueFormatter::new(out).format());
         return Ok(());
     } else {
         log::debug!("No data returned from the module {}", name);


### PR DESCRIPTION
This allows launch modules locally by a minion. Especially useful for Python modules,
those are not processed by any external default interpreter. This feature is basically
a "dev mode" for Python scripts, even though this facility can launch also any other
module.

Example:

    sysminion module -n foo.example -o help