### PR TITLE
Python library placement

### DIFF
--- a/libmodpak/src/lib.rs
+++ b/libmodpak/src/lib.rs
@@ -210,11 +210,9 @@ impl SysInspectModPakMinion {
                     log::error!("Failed to download library {}: {}", lf.file().display(), resp.status());
                     continue;
                 }
-                let buff = resp
-                    .bytes()
-                    .await
-                    .map_err(|e| SysinspectError::MasterGeneralError(format!("Failed to read response: {}", e)))?;
-                let dst = self.cfg.sharelib_dir().join(DEFAULT_MODULES_LIB_DIR).join(lf.file());
+                let buff = resp.bytes().await.map_err(|e| SysinspectError::MasterGeneralError(format!("Failed to read response: {}", e)))?;
+                //let dst = self.cfg.sharelib_dir().join(DEFAULT_MODULES_LIB_DIR).join(lf.file());
+                let dst = self.cfg.sharelib_dir().join(lf.file());
 
                 log::debug!("Writing library to {} ({} bytes)", dst.display().to_string().bright_yellow(), buff.len());
 


### PR DESCRIPTION
Repository has "/lib" for _any_ libraries, including `.so`, shell etc, if any. But Python has `lib` too, so it results into `/lib/lib` and thus breaks Python subsystem. Current solution is to place everything under repo's `lib` into sharelib directly "As is".