### PR TITLE
Bugfix: --shutdown caused bogus logging errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 	cargo clean
 
 check:
-	cargo clippy --all -- -Dwarnings -Aunused-variables -Adead-code
+	cargo clippy --no-deps --all -- -Dwarnings -Aunused-variables -Adead-code
 
 fix:
 	cargo clippy --fix --allow-dirty --allow-staged --all

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -17,7 +17,8 @@ use libsysinspect::{
     cfg::mmconf::{CFG_MODELS_ROOT, MasterConfig},
     mdescr::{mspec::MODEL_FILE_EXT, mspecdef::ModelSpec, telemetry::DataExportType},
     proto::{
-        self, MasterMessage, MinionMessage, MinionTarget, ProtoConversion, errcodes::ProtoErrorCode, payload::ModStatePayload, rqtypes::RequestType,
+        self, MasterMessage, MinionMessage, MinionTarget, ProtoConversion, errcodes::ProtoErrorCode, payload::ModStatePayload, query::SCHEME_COMMAND,
+        rqtypes::RequestType,
     },
     util::{self, iofs::scan_files_sha256},
 };
@@ -121,10 +122,13 @@ impl SysMaster {
             return;
         }
 
-        let scheme = scheme.split('/').next().unwrap_or_default();
-
         // Skip command scheme
-        if scheme.eq("cmd:") {
+        if scheme.starts_with(SCHEME_COMMAND) {
+            return;
+        }
+        let scheme = scheme.split('/').next().unwrap_or_default();
+        if scheme.is_empty() {
+            log::error!("No model scheme found");
             return;
         }
 


### PR DESCRIPTION
When calling `sysinspect --shutdown`, this caused on a master similar output:
```
[13/06/2025 15:39:54] - INFO: Loading model spec from /etc/sysinspect/data/models/cmd:/model.cfg
[13/06/2025 15:39:54] - ERROR: Unable to load model: No such file or directory (os error 2)
```