### PR TITLE
Implement concept of context

### DIFF
--- a/libsysinspect/src/context/mod.rs
+++ b/libsysinspect/src/context/mod.rs
@@ -1,0 +1,65 @@
+use indexmap::IndexMap;
+use serde_json::{Number, Value};
+
+/// Parse a string into a serde_json::Value
+fn get_json_value(s: &str) -> Value {
+    let trimmed = s.trim();
+
+    // Null
+    if trimmed.eq_ignore_ascii_case("null") || trimmed == "~" {
+        return Value::Null;
+    }
+    // Bool
+    if trimmed.eq_ignore_ascii_case("true") {
+        return Value::Bool(true);
+    }
+    if trimmed.eq_ignore_ascii_case("false") {
+        return Value::Bool(false);
+    }
+    // Int (accepts only if string is identical to its integer representation)
+    if let Ok(i) = trimmed.parse::<i64>() {
+        if trimmed == i.to_string() {
+            return Value::Number(Number::from(i));
+        }
+    }
+    // Float (but not if it parses as int)
+    if let Ok(f) = trimmed.parse::<f64>() {
+        if trimmed.contains('.') {
+            if let Some(num) = Number::from_f64(f) {
+                return Value::Number(num);
+            }
+        }
+    }
+    // Quoted string
+    if (trimmed.starts_with('"') && trimmed.ends_with('"')) || (trimmed.starts_with('\'') && trimmed.ends_with('\'')) {
+        return Value::String(trimmed[1..trimmed.len() - 1].to_string());
+    }
+
+    // No clue, therefore just a string
+    Value::String(trimmed.to_string())
+}
+
+/// Get context data from a string
+pub fn get_context(context: &str) -> Option<IndexMap<String, serde_json::Value>> {
+    let context = context.trim();
+    if context.is_empty() {
+        return None;
+    }
+
+    let context: IndexMap<String, Value> = context
+        .split(',')
+        .filter_map(|pair| {
+            let mut parts = pair.splitn(2, ':');
+            match (parts.next(), parts.next()) {
+                (Some(k), Some(v)) => Some((k.trim().to_string(), get_json_value(v))),
+                _ => None,
+            }
+        })
+        .collect();
+
+    if context.is_empty() {
+        return None;
+    }
+
+    Some(context)
+}

--- a/libsysinspect/src/inspector.rs
+++ b/libsysinspect/src/inspector.rs
@@ -7,6 +7,7 @@ use crate::{
     traits::systraits::SystemTraits,
 };
 use colored::Colorize;
+use indexmap::IndexMap;
 use intp::actproc::response::ActionResponse;
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
@@ -24,6 +25,11 @@ pub struct SysInspectRunner {
 
     // Minion traits, if running in distributed mode
     traits: Option<SystemTraits>,
+
+    // Minion context runtime values. These are used to pass additional information
+    // to the model at runtime call. They are typically used to pass
+    // information about the environment or some IDs or any other volatile data.
+    context: Option<IndexMap<String, serde_json::Value>>,
 
     // Constraints evaluation results ID/outcome.
     cstr_f: Vec<String>, // constraints that failed
@@ -88,9 +94,7 @@ impl SysInspectRunner {
 
         for c in a.if_false() {
             if !self.cstr_s.contains(&c) && !self.cstr_f.contains(&c) {
-                return Err(SysinspectError::ModelDSLError(format!(
-                    "Constraint {c} expected to be already failed. Please fix your model."
-                )));
+                return Err(SysinspectError::ModelDSLError(format!("Constraint {c} expected to be already failed. Please fix your model.")));
             }
 
             if !self.cstr_f.contains(&c) {
@@ -100,9 +104,7 @@ impl SysInspectRunner {
 
         for c in a.if_true() {
             if !self.cstr_s.contains(&c) && !self.cstr_f.contains(&c) {
-                return Err(SysinspectError::ModelDSLError(format!(
-                    "Constraint {c} expected to be already succeeded. Please fix your model."
-                )));
+                return Err(SysinspectError::ModelDSLError(format!("Constraint {c} expected to be already succeeded. Please fix your model.")));
             }
 
             if !self.cstr_s.contains(&c) {
@@ -190,7 +192,13 @@ impl SysInspectRunner {
         };
     }
 
+    /// Set minion traits
     pub fn set_traits(&mut self, traits: SystemTraits) {
         self.traits = Some(traits);
+    }
+
+    /// Set minion context variables
+    pub fn set_context(&mut self, context: Option<IndexMap<String, serde_json::Value>>) {
+        self.context = context;
     }
 }

--- a/libsysinspect/src/lib.rs
+++ b/libsysinspect/src/lib.rs
@@ -4,6 +4,7 @@ use std::{error::Error, ffi::NulError, io};
 use thiserror::Error;
 
 pub mod cfg;
+pub mod context;
 pub mod inspector;
 pub mod intp;
 pub mod logger;

--- a/libsysinspect/src/proto/mod.rs
+++ b/libsysinspect/src/proto/mod.rs
@@ -70,12 +70,12 @@ impl MasterMessage {
     }
 
     /// Get targeting means
-    pub fn get_target(&self) -> &MinionTarget {
+    pub fn target(&self) -> &MinionTarget {
         &self.target
     }
 
     /// Get cycle ID (message ID)
-    pub fn get_cycle(&self) -> &String {
+    pub fn cycle(&self) -> &String {
         &self.cycle
     }
 }
@@ -165,6 +165,9 @@ pub struct MinionTarget {
 
     #[serde(rename = "h")]
     hostnames: Vec<String>,
+
+    #[serde(rename = "cq")]
+    context_query: String,
 }
 
 impl MinionTarget {
@@ -194,6 +197,11 @@ impl MinionTarget {
         &self.scheme
     }
 
+    /// Get context query
+    pub fn context(&self) -> &String {
+        &self.context_query
+    }
+
     /// Set scheme
     pub fn set_scheme(&mut self, scheme: &str) {
         self.scheme = scheme.to_string();
@@ -202,6 +210,11 @@ impl MinionTarget {
     /// Set traits query
     pub fn set_traits_query(&mut self, traits: &str) {
         self.traits_query = traits.to_string();
+    }
+
+    /// Get context query
+    pub fn set_context_query(&mut self, context: &str) {
+        self.context_query = context.to_string();
     }
 
     /// Traits query itself.

--- a/src/clidef.rs
+++ b/src/clidef.rs
@@ -51,6 +51,13 @@ pub fn cli(version: &'static str) -> Command {
                 .long("traits")
                 .help("Specify traits to select remote systems")
         )
+        .arg(
+            Arg::new("context")
+                .short('x')
+                .long("context")
+                .help(format!("Provide context data as comma-separated key-value pairs to minions when evaluating and running the model.\n{}",
+                              "Example: --context='myvar:123,myothervar:\"John Smith\"'".yellow()))
+        )
 
         // Local
         .next_help_heading("Local")

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -185,7 +185,7 @@ impl SysMaster {
     fn msg_query(&mut self, payload: &str) -> Option<MasterMessage> {
         let query = payload.split(";").map(|s| s.to_string()).collect::<Vec<String>>();
         if let [querypath, query, traits, mid, context] = query.as_slice() {
-            log::debug!("Context: {}", context);
+            log::debug!("Context: {context}");
             let mut tgt = MinionTarget::new(mid, "");
             tgt.set_scheme(querypath);
             tgt.set_traits_query(traits);

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -17,6 +17,7 @@ use libsysinspect::{
         get_minion_config,
         mmconf::{DEFAULT_PORT, MinionConfig, SysInspectConfig},
     },
+    context,
     inspector::SysInspectRunner,
     intp::{
         actproc::{modfinder::ModCall, response::ActionResponse},
@@ -208,7 +209,7 @@ impl SysMinion {
                     }
                 };
 
-                log::trace!("Received: {msg:#?}");
+                log::trace!("Received Master message: {msg:#?}");
 
                 match msg.req_type() {
                     RequestType::Add => {
@@ -371,7 +372,7 @@ impl SysMinion {
     }
 
     /// Launch sysinspect
-    async fn launch_sysinspect(self: Arc<Self>, cycle_id: &str, scheme: &str, msp: &ModStatePayload) {
+    async fn launch_sysinspect(self: Arc<Self>, cycle_id: &str, scheme: &str, msp: &ModStatePayload, context: &str) {
         // Get the query first
         let mqr = match MinionQuery::new(scheme) {
             Ok(mqr) => mqr,
@@ -432,6 +433,7 @@ impl SysMinion {
         sr.set_entities(mqr_l.entities());
         sr.set_checkbook_labels(mqr_l.checkbook_labels());
         sr.set_traits(traits::get_minion_traits(None));
+        sr.set_context(context::get_context(context));
 
         sr.add_action_callback(Box::new(ActionResponseCallback::new(self.as_ptr(), cycle_id)));
         sr.add_model_callback(Box::new(ModelResponseCallback::new(self.as_ptr(), cycle_id)));
@@ -477,12 +479,12 @@ impl SysMinion {
 
         log::debug!("Dispatching message: {cmd:#?}");
 
-        if cmd.get_cycle().is_empty() {
+        if cmd.cycle().is_empty() {
             log::error!("Cycle ID is empty!");
             return;
         }
 
-        let tgt = cmd.get_target();
+        let tgt = cmd.target();
 
         // Is command minion-specific?
         if !tgt.id().is_empty() && tgt.id().ne(&self.get_minion_id()) {
@@ -535,10 +537,10 @@ impl SysMinion {
 
         match PayloadType::try_from(cmd.payload().clone()) {
             Ok(PayloadType::ModelOrStatement(pld)) => {
-                if cmd.get_target().scheme().starts_with(SCHEME_COMMAND) {
-                    self.as_ptr().call_internal_command(cmd.get_target().scheme()).await;
+                if cmd.target().scheme().starts_with(SCHEME_COMMAND) {
+                    self.as_ptr().call_internal_command(cmd.target().scheme()).await;
                 } else {
-                    self.as_ptr().launch_sysinspect(cmd.get_cycle(), cmd.get_target().scheme(), &pld).await;
+                    self.as_ptr().launch_sysinspect(cmd.cycle(), cmd.target().scheme(), &pld, cmd.target().context()).await;
                     log::debug!("Command dispatched");
                     log::debug!("Command payload: {pld:#?}");
                 }


### PR DESCRIPTION
This is equivalent to Salt's "pillars". Context allows user to define variables they want to send across the cluster and minions will pick them up into their model instances, interpolating the data.