### PR TITLE
Isbm issue 103

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package/
 /*/.venv/
 /*/.bin/
 /*/html-docs
+.gitignore

--- a/docs/evthandlers/overview.rst
+++ b/docs/evthandlers/overview.rst
@@ -5,13 +5,6 @@ Event Handlers
 
     This document section lists and explains available event handlers.
 
-.. toctree::
-   :maxdepth: 1
-
-   console_logger
-   outcome_logger
-   pipescript
-
 Overview
 --------
 
@@ -21,3 +14,59 @@ sends a notification email to a configured list of recipients or call an externa
 
 Each event handler can be defined with the event type and the corresponding action to ensure proper handling of the
 event based on system requirements.
+
+Event Filter Format
+-------------------
+
+.. important::
+
+    🚨 If you define the filter format incorrectly, you won't get any reaction and the event will be ignored.
+    Additionally, **no logging will be emitted** unless in debug mode.
+
+Event has the following format:
+
+.. code-block:: text
+
+    action/entity/state/exit-code
+
+Keeping this in mind, following the following module structure, we can define events as following:
+
+.. code-block:: yaml
+
+    actions:
+      my-great-action:  # This is the action ID
+        ...
+        bind:
+          - some-entity # This is the entity ID
+        state:
+          some-state:   # This is the state ID
+            ...
+
+    events:
+      my-great-action/some-entity/some-state/0: # React only on successes
+         ...
+
+      my-great-action/some-entity/some-state/E: # React only on errors
+         ...
+
+      my-great-action/some-entity/some-state/$: # React on all exit codes
+         ...
+
+
+
+Each of these values can be also wildcarded (e.g., ``my-action/$/some-state/0``). In this case event filter will
+call a specific handler only if an action "my-action" with "some-state" will be called and the result exit code matches "0".
+This means, to catch all events from all actions, use ``$/$/$/$`` event filter.
+
+
+Available Handlers
+------------------
+
+Here are the available event handlers:
+
+.. toctree::
+   :maxdepth: 1
+
+   console_logger
+   outcome_logger
+   pipescript

--- a/docs/modeldescr/functions.rst
+++ b/docs/modeldescr/functions.rst
@@ -26,7 +26,7 @@ List of currently supported functions:
 ``static(value)``
 
   The function ``static`` accepts a type ``String`` with the whole absolute path with the ID of the claim.
-  A path has ``.`` dot-notation, e.g., ``foo.bar.baz`` where ``baz`` is the final ID.
+  A path uses ``.`` dot-notation, e.g., ``foo.bar.baz`` where ``baz`` is the final ID.
 
 ``context(value)``
 
@@ -37,7 +37,12 @@ List of currently supported functions:
 Data Definition
 ---------------
 
-Data can be defined in ``entities`` section under specific action IDs and states. A state is just a label or
+Here you can find the details about how to use ``claim`` and ``static`` functions.
+
+Claim Functions
+^^^^^^^^^^^^^^^
+
+Data can be defined in the ``entities`` section under specific action IDs and states. A state is just a label or
 unspecified ``$`` *(default state)*. For example:
 
 .. code-block:: yaml
@@ -51,7 +56,7 @@ unspecified ``$`` *(default state)*. For example:
           - otherfact:
               key: othervalue
 
-In this case, ``claim(...)`` function must be called within the same context state, otherwise value will not be found.
+In this case, the ``claim(...)`` function must be called within the same context state, otherwise the value will not be found.
 For example:
 
 .. code-block:: yaml
@@ -72,7 +77,7 @@ In this example, when you use ``claim(key.fact)`` and ``claim(key.otherfact)``, 
 Think of a "state" as a label for a certain situation or version of your data. If you use the label ``my_state``, you
 must also use ``my_state`` everywhere you want to access those values. There is also a default state, written as ``$``.
 But be careful: if you are working in a specific state (like ``my_state``), the default state ``$`` is not the same
-thing. Data in the default state will not automatically appear in a specific state, and the other way around. So, if you
+thing. Data in the default state will not automatically appear in a specific state, and vice versa. So, if you
 try to get a value from the default state while you are in a specific state, it won't work.
 
 .. note::
@@ -84,7 +89,7 @@ try to get a value from the default state while you are in a specific state, it 
 
 In short: always make sure your action and your data use the same state label if you want to access the right values.
 
-Fall back values are defined with ``?`` (question mark) symbol and they are not belonging to any specific state.
+Fallback values are defined with the ``?`` (question mark) symbol and they do not belong to any specific state.
 They can be used to provide default values when the main value is not available. For example:
 
 .. code-block:: yaml
@@ -110,11 +115,75 @@ They can be used to provide default values when the main value is not available.
         foo: claim(fact.key)
         bar: claim(otherfact.key)
 
-In this case ``fact.key`` will return ``value`` because it is defined in the fallback state ``?``, while
+In this case, ``fact.key`` will return ``value`` because it is defined in the fallback state ``?``, while
 ``otherfact.key`` will return ``othervalue`` because it is defined in the specific state ``my_state``.
+
+Static Functions
+^^^^^^^^^^^^^^^^
+
+Static functions are a way to grab data that never changes, no matter where you are in your system. Think of
+them like a street address: if you know the address, you can always find the house, no matter where you’re
+standing. These functions ignore what action or state you’re in—they just go straight to the data you asked
+for.
+
+.. hint::
+
+  If ``claim`` is like asking for something in your own room (it depends on where you are), ``static`` is
+  like looking up a friend’s address in your phone and going straight there. It doesn’t matter where you
+  start from—you’ll always end up at the same place.
+
+Static functions don’t have backup or fallback values. If you ask for something that doesn’t exist at the
+address you gave, you just get nothing. You can only set up static data in the ``entities`` section. Here’s
+how you define a static value:
+
+.. code-block:: yaml
+
+  entities:
+    my_entity:
+      claims:
+        my_state:
+          - label:
+              name: Fred
+
+It doesn’t matter what you call the state here (even if it’s made up), because static functions don’t care
+about states—they just want the full path to the data. The important thing is that your data is under the
+``claims`` section of your entity. That’s where static functions look.
+
+To use a static function, you give it the full path to the value you want, like this:
+
+.. code-block:: yaml
+
+  actions:
+    my_action:
+      bind:
+        - my_entity
+      module: mymodule
+      args:
+        name: static(entities.my_entity.claims.my_state.label.name)
+
+Here, the static function will always find "Fred" and put it into the ``name`` argument, no matter what
+action or state you’re in. It’s like having a shortcut that always works, as long as you spell the path
+correctly!
+
+.. important::
+
+  Static functions require the path to start with ``entities. ...``. The path has the following structure (see
+  the YAML example above):
+
+  .. code-block:: text
+
+    entities.<entity>.<region>.<state>.<label>.<key>
+    ^        ^        ^        ^       ^       ^
+    entities.my_entity.claims.my_state.label.name
 
 Conditional Function Processing
 -------------------------------
+
+The model supports Jinja2 templating syntax and conditions.
+
+.. important::
+
+  This is not real Jinja2 templating, only a simplified version without a real Python interpreter behind it!
 
 If there is a function, say ``context(foo)``, that returns a value, but you want to check if that value is defined,
 you can use the template conditional syntax:
@@ -144,5 +213,6 @@ For example, this technique can be used to define module parameters based on the
         baz: "context(tgt)"
       {% endif %}
 
-Of course, under these circumstances, the ``context(somevalue)`` and ``{{ context.somevalue }}`` are the same thing,
+Of course, under these circumstances, ``context(somevalue)`` and ``{{ context.somevalue }}`` are the same thing,
 just one is used as a fact function, and the other is direct access to the context variable using Jinja syntax.
+

--- a/libsysinspect/src/intp/conf.rs
+++ b/libsysinspect/src/intp/conf.rs
@@ -1,10 +1,13 @@
-use crate::{SysinspectError, cfg::mmconf::DEFAULT_MODULES_DIR, util};
+use super::inspector::get_cfg_sharelib;
+use crate::{
+    SysinspectError,
+    cfg::mmconf::DEFAULT_MODULES_DIR,
+    util::dataconv::{as_bool_opt, as_int_opt, as_str_list_opt, as_str_opt},
+};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use std::path::PathBuf;
-
-use super::inspector::get_cfg_sharelib;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct EventConfigOption {
@@ -15,22 +18,22 @@ pub struct EventConfigOption {
 impl EventConfigOption {
     /// Get an option as a string type
     pub fn as_string(&self, cfg: &str) -> Option<String> {
-        util::dataconv::as_str_opt(self.data.get(cfg).cloned())
+        as_str_opt(self.data.get(cfg).cloned())
     }
 
     /// Get an option as an integer
     pub fn as_int(&self, cfg: &str) -> Option<i64> {
-        util::dataconv::as_int_opt(self.data.get(cfg).cloned())
+        as_int_opt(self.data.get(cfg).cloned())
     }
 
     /// Get an option as an integer
     pub fn as_bool(&self, cfg: &str) -> Option<bool> {
-        util::dataconv::as_bool_opt(self.data.get(cfg).cloned())
+        as_bool_opt(self.data.get(cfg).cloned())
     }
 
     /// Get an option as a vector of strings
     pub fn as_str_list(&self, cfg: &str) -> Option<Vec<String>> {
-        util::dataconv::as_str_list_opt(self.data.get(cfg).cloned())
+        as_str_list_opt(self.data.get(cfg).cloned())
     }
 }
 
@@ -38,7 +41,7 @@ impl EventConfigOption {
 /// binding handlers and their configurations, respectfully.
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct EventConfig {
-    handler: Vec<String>,
+    handlers: Vec<String>,
     #[serde(flatten)]
     cfg: Option<IndexMap<String, EventConfigOption>>,
 }
@@ -56,7 +59,7 @@ impl EventConfig {
 
     /// Get all handlers that are bound to
     pub(crate) fn get_bound_handlers(&self) -> &Vec<String> {
-        &self.handler
+        &self.handlers
     }
 
     /// Get specific event configuration by a handler Id (`hid`).

--- a/libsysinspect/src/intp/inspector.rs
+++ b/libsysinspect/src/intp/inspector.rs
@@ -270,7 +270,8 @@ impl SysInspector {
             let entity = Entity::default();
             let entity = self.get_entity(eid).unwrap_or(&entity);
             if let Some(claims) = entity.claims() {
-                if let Some(claims) = claims.get(state) {
+                // State-specific, or look for a fallback ("?") if any
+                if let Some(claims) = claims.get(state).or_else(|| claims.get("?")) {
                     for claim in claims {
                         if let Some(v) = claim.get(func.ns().get(ClaimNamespace::LABEL as usize).unwrap()) {
                             return Ok(functions::get_by_namespace(Some(v).cloned(), func.ns()[1..].join(".").as_str()));

--- a/libsysinspect/src/reactor/evtproc.rs
+++ b/libsysinspect/src/reactor/evtproc.rs
@@ -1,3 +1,4 @@
+
 use super::{callback::EventProcessorCallback, handlers::evthandler::EventHandler, receiver::Receiver};
 use crate::{
     intp::conf::Config,
@@ -38,9 +39,7 @@ impl<'a> EventProcessor<'a> {
         for evt_id in cfg.get_event_ids() {
             let evt_cfg = cfg.get_event(&evt_id).unwrap();
             for handler_id in evt_cfg.get_bound_handlers() {
-                if let Some(handler) =
-                    handlers::registry::init_handler(handler_id.to_string(), evt_id.to_string(), evt_cfg.to_owned())
-                {
+                if let Some(handler) = handlers::registry::init_handler(handler_id.to_string(), evt_id.to_string(), evt_cfg.to_owned()) {
                     self.handlers.push(handler);
                     log::debug!("Registered handler: {handler_id} on {evt_id}")
                 } else {

--- a/libsysinspect/src/reactor/handlers/pipescript.rs
+++ b/libsysinspect/src/reactor/handlers/pipescript.rs
@@ -18,6 +18,7 @@ use std::{
 
 #[derive(Default, Debug)]
 pub struct PipeScriptHandler {
+    eid: String,
     cfg: EventConfig,
 }
 
@@ -39,6 +40,12 @@ impl PipeScriptHandler {
     fn call_script(&self, evt: &ActionResponse) {
         // Successfull responses only
         if evt.response.retcode() > 0 {
+            return;
+        }
+
+        // Skip events that doesn't belong
+        if !evt.match_eid(&self.eid) {
+            log::debug!("Event {} doesn't match handler {}", evt.eid().bright_yellow(), self.eid.bright_yellow());
             return;
         }
 
@@ -77,11 +84,11 @@ impl PipeScriptHandler {
 
 /// Pipescript handler
 impl EventHandler for PipeScriptHandler {
-    fn new(_eid: String, cfg: crate::intp::conf::EventConfig) -> Self
+    fn new(eid: String, cfg: crate::intp::conf::EventConfig) -> Self
     where
         Self: Sized,
     {
-        PipeScriptHandler { cfg }
+        PipeScriptHandler { eid, cfg }
     }
 
     fn id() -> String

--- a/libsysinspect/src/reactor/handlers/pipescript.rs
+++ b/libsysinspect/src/reactor/handlers/pipescript.rs
@@ -81,6 +81,25 @@ impl PipeScriptHandler {
                         log::info!("{} - {}", "Pipescript".cyan(), cmd.join(" "));
                     }
                 }
+
+                // Log stuff
+                if !quiet {
+                    match p.wait_with_output() {
+                        Ok(output) => {
+                            let stdout = String::from_utf8_lossy(&output.stdout);
+                            let stderr = String::from_utf8_lossy(&output.stderr);
+
+                            if !stdout.trim().is_empty() {
+                                log::info!("{} STDOUT: {}", "Pipescript".cyan(), stdout.trim());
+                            }
+
+                            if !stderr.trim().is_empty() {
+                                log::warn!("{} STDERR: {}", "Pipescript".cyan(), stderr.trim());
+                            }
+                        }
+                        Err(e) => log::error!("Failed to read output from '{}': {}", cmd.join(" "), e),
+                    }
+                }
             }
             Err(err) => log::error!("{} error: {} for '{}'", PipeScriptHandler::id(), err, cmd.join(" ")),
         };

--- a/libsysinspect/src/tmpl/render.rs
+++ b/libsysinspect/src/tmpl/render.rs
@@ -48,7 +48,7 @@ impl ModelTplRender {
 
         for (key, value) in input {
             if bogus.contains(&key) {
-                log::warn!("Skipping bogus namespace: {}", key.bright_yellow().bold());
+                log::debug!("Skipping bogus namespace: {}", key.bright_yellow().bold());
                 continue;
             }
 


### PR DESCRIPTION
This PR:
- [x] Fixes bug when `pipescript` ignores entity filter and is fired every time on everything
- [x] Formalises a better JSON output data that `pipescript` sends to the target program over STDIN
- [x] Updates documentation on `pipescript`
- [x] Closes #103 
- [x] Updates documentation on static and claim functions, their usage and fall-back data definition.