### PR TITLE
Bug: auto-reconnect on longer sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7187,6 +7187,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sysinfo 0.34.2",
+ "tempfile",
  "tokio",
  "uuid",
 ]

--- a/sysminion/Cargo.toml
+++ b/sysminion/Cargo.toml
@@ -45,3 +45,4 @@ libc = "0.2.180"
 async-trait = "0.1.89"
 futures = "0.3.31"
 procfs = { version = "0.18.0", features = ["serde"] }
+tempfile = "3.25.0"

--- a/sysminion/src/main.rs
+++ b/sysminion/src/main.rs
@@ -6,6 +6,9 @@ mod proto;
 mod ptcounter;
 mod rsa;
 
+#[cfg(test)]
+mod minion_ut;
+
 use clap::{ArgMatches, Command};
 use clidef::cli;
 use daemonize::Daemonize;

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -237,7 +237,7 @@ impl SysMinion {
     }
 
     /// Talk-back to the master
-    async fn request(&self, msg: Vec<u8>) {
+    pub(crate) async fn request(&self, msg: Vec<u8>) {
         let mut stm = self.wstm.lock().await;
 
         if let Err(e) = stm.write_all(&(msg.len() as u32).to_be_bytes()).await {

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -79,8 +79,8 @@ pub struct SysMinion {
 
     filedata: Mutex<MinionFiledata>,
 
-    last_ping: Mutex<Instant>,
-    ping_timeout: Duration,
+    pub(crate) last_ping: Mutex<Instant>,
+    pub(crate) ping_timeout: Duration,
 
     pt_counter: Mutex<PTCounter>,
     dpq: Arc<DiskPersistentQueue>,
@@ -222,7 +222,7 @@ impl SysMinion {
         println!("{}:\n\n{}", "Minion information".bright_green().bold(), fmt.format());
     }
 
-    async fn update_ping(&self) {
+    pub(crate) async fn update_ping(&self) {
         let mut last_ping = self.last_ping.lock().await;
         *last_ping = Instant::now();
     }
@@ -889,6 +889,11 @@ impl SysMinion {
                 log::error!("Error dispatching command: {err}");
             }
         }
+    }
+
+    #[cfg(test)]
+    pub fn set_ping_timeout(&mut self, d: Duration) {
+        self.ping_timeout = d;
     }
 }
 

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -891,7 +891,7 @@ impl SysMinion {
 }
 
 /// Constructs and starts an actual minion
-async fn _minion_instance(cfg: MinionConfig, fingerprint: Option<String>, dpq: Arc<DiskPersistentQueue>) -> Result<(), SysinspectError> {
+pub(crate) async fn _minion_instance(cfg: MinionConfig, fingerprint: Option<String>, dpq: Arc<DiskPersistentQueue>) -> Result<(), SysinspectError> {
     let state = Arc::new(ExitState::new());
     let modpak = SysInspectModPakMinion::new(cfg.clone());
     let minion = SysMinion::new(cfg.clone(), fingerprint, dpq).await?;

--- a/sysminion/src/minion_ut.rs
+++ b/sysminion/src/minion_ut.rs
@@ -212,15 +212,11 @@ mod tests {
         minion.as_ptr().send_ehlo().await.unwrap();
 
         let msg = server.await.unwrap();
-        let s = String::from_utf8_lossy(&msg);
+        let v: serde_json::Value = serde_json::from_slice(&msg).unwrap();
 
-        // "JSON-ish" sanity (your proto is JSON payloads wrapped in framing)
-        assert!(s.contains("{"), "ehlo payload not json-ish: {s}");
-        assert!(s.contains(&MINION_SID.to_string()), "ehlo payload missing sid {}: {s}", *MINION_SID);
-
-        // If your encoding uses strings, this will pass.
-        // If you encode req_type as a number, replace this with whatever marker is present.
-        assert!(s.contains("\"r\":\"ehlo\""), "ehlo payload doesn't look like an Ehlo message: {s}");
+        assert_eq!(v["r"], "ehlo");
+        assert_eq!(v["sid"], MINION_SID.to_string());
+        assert!(v["d"].is_object());
     }
 
     #[tokio::test]
@@ -255,9 +251,10 @@ mod tests {
         minion.as_ptr().send_traits().await.unwrap();
 
         let msg = server.await.unwrap();
-        let s = String::from_utf8_lossy(&msg);
+        let v: serde_json::Value = serde_json::from_slice(&msg).unwrap();
 
-        assert!(s.contains(&MINION_SID.to_string()), "traits missing sid: {s}");
-        assert!(s.contains("\"r\":\"tr\""), "traits message doesn't look right: {s}");
+        assert_eq!(v["r"], "tr");
+        assert_eq!(v["sid"], MINION_SID.to_string());
+        assert!(v["d"].is_object());
     }
 }

--- a/sysminion/src/minion_ut.rs
+++ b/sysminion/src/minion_ut.rs
@@ -1,0 +1,83 @@
+#[cfg(test)]
+mod tests {
+    use crate::minion::{_minion_instance, SysMinion};
+    use crate::proto::msg::CONNECTION_TX;
+    use libdpq::DiskPersistentQueue;
+    use libsysinspect::cfg::mmconf::MinionConfig;
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+    use tokio::time::{Duration, timeout};
+
+    fn mk_cfg(master: String, fileserver: String, root: &std::path::Path) -> MinionConfig {
+        let mut cfg = MinionConfig::default();
+        cfg.set_master_ip(master.split(':').next().unwrap_or("127.0.0.1"));
+        cfg.set_master_port(master.split(':').nth(1).unwrap().parse().unwrap());
+        //cfg.set_fileserver(fileserver);
+        cfg.set_root_dir(root.to_str().unwrap());
+        cfg.set_reconnect_freq(0);
+        cfg.set_reconnect_interval("1");
+        cfg
+    }
+
+    #[tokio::test]
+    async fn reconnect_signal_exits_instance_cleanly() {
+        // Fake master
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Accept connection and just sit there
+        tokio::spawn(async move {
+            let (_sock, _peer) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = mk_cfg(
+            format!("{}", addr),
+            "127.0.0.1:1".to_string(), // not used in this test
+            tmp.path(),
+        );
+
+        let dpq = Arc::new(DiskPersistentQueue::open(tmp.path().join("pending-tasks")).unwrap());
+
+        let h = tokio::spawn(async move { _minion_instance(cfg, None, dpq).await });
+
+        // Let it start
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Trigger reconnect
+        let _ = CONNECTION_TX.send(());
+
+        // Must exit quickly
+        let res = timeout(Duration::from_secs(2), h).await;
+        assert!(res.is_ok(), "instance did not exit on reconnect");
+    }
+
+    #[tokio::test]
+    async fn proto_eof_emits_reconnect_signal() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (sock, _) = listener.accept().await.unwrap();
+            drop(sock); // immediate EOF for minion
+        });
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = MinionConfig::default();
+        cfg.set_master_ip("127.0.0.1");
+        cfg.set_master_port(addr.port().into());
+        cfg.set_root_dir(tmp.path().to_str().unwrap());
+        cfg.set_reconnect_freq(0);
+        cfg.set_reconnect_interval("1");
+
+        let dpq = Arc::new(DiskPersistentQueue::open(tmp.path().join("pending-tasks")).unwrap());
+        let minion = SysMinion::new(cfg, None, dpq).await.unwrap();
+
+        let mut rx = CONNECTION_TX.subscribe();
+        minion.as_ptr().do_proto().await.unwrap();
+
+        let got = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await;
+        assert!(got.is_ok(), "expected reconnect signal on EOF");
+    }
+}

--- a/sysminion/src/minion_ut.rs
+++ b/sysminion/src/minion_ut.rs
@@ -141,4 +141,43 @@ mod tests {
         h2.abort();
         let _ = h2.await;
     }
+
+    #[tokio::test]
+    async fn request_writes_len_prefix_and_payload() {
+        use super::*;
+        use tokio::io::AsyncReadExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+
+            let mut lenb = [0u8; 4];
+            sock.read_exact(&mut lenb).await.unwrap();
+            let n = u32::from_be_bytes(lenb) as usize;
+
+            let mut msg = vec![0u8; n];
+            sock.read_exact(&mut msg).await.unwrap();
+
+            (n, msg)
+        });
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = MinionConfig::default();
+        cfg.set_master_ip(&addr.ip().to_string());
+        cfg.set_master_port(addr.port().into());
+        cfg.set_root_dir(tmp.path().to_str().unwrap());
+
+        let dpq = Arc::new(DiskPersistentQueue::open(tmp.path().join("pending-tasks")).unwrap());
+        let minion = SysMinion::new(cfg, None, dpq).await.unwrap();
+
+        let payload = b"abc123".to_vec();
+        minion.request(payload.clone()).await;
+
+        let (n, msg) = server.await.unwrap();
+        assert_eq!(n, payload.len());
+        assert_eq!(msg, payload);
+    }
 }

--- a/sysminion/src/minion_ut.rs
+++ b/sysminion/src/minion_ut.rs
@@ -77,7 +77,21 @@ mod tests {
         let mut rx = CONNECTION_TX.subscribe();
         minion.as_ptr().do_proto().await.unwrap();
 
+        // let proto loop actually start
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
         let got = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await;
         assert!(got.is_ok(), "expected reconnect signal on EOF");
+        match got {
+            Ok(Ok(_)) => {
+                // correct: reconnect signal received
+            }
+            Ok(Err(e)) => {
+                panic!("channel closed unexpectedly: {e}");
+            }
+            Err(_) => {
+                panic!("expected reconnect signal on EOF but timed out");
+            }
+        }
     }
 }


### PR DESCRIPTION
This sneaked-in: minion reconnects mid-sync if repo takes long enough.