### PR TITLE
Add fs.dir module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dir"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "serde_json",
+]
+
+[[package]]
 name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "sysmaster",
     "sysminion",
     "modules/fs/file",
+    "modules/fs/dir",
     "libsetup",
     "libmodpak",
     "libscheduler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ members = [
     "libdatastore",
     "modules/cfg/resource"]
 
+[profile.dev]
+panic = "abort"
+
 [profile.release]
 strip = true
 opt-level = "z"

--- a/Makefile.in
+++ b/Makefile.in
@@ -219,6 +219,7 @@ define stage_profile_modules
 	if [ -f "$$build_dir/ssrun" ]; then cp -f "$$build_dir/ssrun" "$$stage_dir/sys/ssrun" && chmod +x "$$stage_dir/sys/ssrun"; fi; \
 	if [ -f "$$build_dir/user" ]; then cp -f "$$build_dir/user" "$$stage_dir/sys/user" && chmod +x "$$stage_dir/sys/user"; fi; \
 	if [ -f "$$build_dir/service" ]; then cp -f "$$build_dir/service" "$$stage_dir/sys/service" && chmod +x "$$stage_dir/sys/service"; fi; \
+	if [ -f "$$build_dir/pkg" ]; then cp -f "$$build_dir/pkg" "$$stage_dir/sys/pkg" && chmod +x "$$stage_dir/sys/pkg"; fi; \
 		if [ -f "$build_dir/http-mod" ]; then cp -f "$build_dir/http-mod" "$stage_dir/net/http" && chmod +x "$stage_dir/net/http"; fi; \
 
 	if [ -f "$$build_dir/file" ]; then cp -f "$$build_dir/file" "$$stage_dir/fs/file" && chmod +x "$$stage_dir/fs/file"; fi; \
@@ -255,7 +256,8 @@ define stage_modules_dist
 			net) rel=sys/net ;; \
 			run) rel=sys/run ;; \
 			ssrun) rel=sys/ssrun ;; \
-user) rel=sys/user ;; \
+			user) rel=sys/user ;; \
+			pkg) rel=sys/pkg ;; \
 service) rel=sys/service ;; \
 			http-mod) rel=net/http ;; \
 			file) rel=fs/file ;; \

--- a/Makefile.in
+++ b/Makefile.in
@@ -223,6 +223,7 @@ define stage_profile_modules
 		if [ -f "$build_dir/http-mod" ]; then cp -f "$build_dir/http-mod" "$stage_dir/net/http" && chmod +x "$stage_dir/net/http"; fi; \
 
 	if [ -f "$$build_dir/file" ]; then cp -f "$$build_dir/file" "$$stage_dir/fs/file" && chmod +x "$$stage_dir/fs/file"; fi; \
+	if [ -f "$$build_dir/dir" ]; then cp -f "$$build_dir/dir" "$$stage_dir/fs/dir" && chmod +x "$$stage_dir/fs/dir"; fi; \
 	if [ -f "$$build_dir/lua-runtime" ]; then cp -f "$$build_dir/lua-runtime" "$$stage_dir/runtime/lua-runtime" && chmod +x "$$stage_dir/runtime/lua-runtime"; fi; \
 	if [ -f "$$build_dir/py3-runtime" ]; then cp -f "$$build_dir/py3-runtime" "$$stage_dir/runtime/py3-runtime" && chmod +x "$$stage_dir/runtime/py3-runtime"; fi; \
 	if [ -f "$$build_dir/wasm-runtime" ]; then cp -f "$$build_dir/wasm-runtime" "$$stage_dir/runtime/wasm-runtime" && chmod +x "$$stage_dir/runtime/wasm-runtime"; fi; \
@@ -261,6 +262,7 @@ define stage_modules_dist
 service) rel=sys/service ;; \
 			http-mod) rel=net/http ;; \
 			file) rel=fs/file ;; \
+			dir) rel=fs/dir ;; \
 			lua-runtime) rel=runtime/lua-runtime ;; \
 			py3-runtime) rel=runtime/py3-runtime ;; \
 			wasm-runtime) rel=runtime/wasm-runtime ;; \
@@ -299,6 +301,7 @@ user) rel=sys/user ;; \
 service) rel=sys/service ;; \
 			http-mod) rel=net/http ;; \
 			file) rel=fs/file ;; \
+			dir) rel=fs/dir ;; \
 			lua-runtime) rel=runtime/lua-runtime ;; \
 			py3-runtime) rel=runtime/py3-runtime ;; \
 			wasm-runtime) rel=runtime/wasm-runtime ;; \
@@ -336,6 +339,7 @@ user) rel=sys/user ;; \
 service) rel=sys/service ;; \
 			http-mod) rel=net/http ;; \
 			file) rel=fs/file ;; \
+			dir) rel=fs/dir ;; \
 			lua-runtime) rel=runtime/lua-runtime ;; \
 			py3-runtime) rel=runtime/py3-runtime ;; \
 			wasm-runtime) rel=runtime/wasm-runtime ;; \

--- a/docs/moddescr/fs_dir.rst
+++ b/docs/moddescr/fs_dir.rst
@@ -1,0 +1,225 @@
+``fs.dir``
+==========
+
+.. note::
+
+    This document describes ``fs.dir`` module usage.
+
+Synopsis
+--------
+
+The ``fs.dir`` module manages directory state through three idempotent
+operations: inspect, ensure, and remove. It checks the current state
+before acting — no unnecessary syscalls, no spurious ``changed`` flags.
+
+The module is ``#![no_std]`` and makes no heap allocations, using only
+raw libc calls. It reads a JSON request on stdin and writes a JSON
+response to stdout.
+
+Usage
+-----
+
+The following options are available (pick exactly one operation):
+
+  ``check``
+    Inspect a directory's existence, type, mode, owner, and group.
+    Returns structured data suitable for CM decision-making. Read-only.
+    Must be combined with argument ``name``.
+
+  ``present``
+    Ensure a directory exists with the given attributes. If it already
+    exists, mode and ownership are updated if they differ. If mode, uid,
+    and gid already match, the module reports no change.
+
+  ``absent``
+    Remove a directory if it exists. If the directory is not there, the
+    module reports success with a descriptive message. Only removes empty
+    directories (``rmdir`` semantics).
+
+  ``dry-run``
+    Can be combined with any operation. Prints what would be done without
+    making changes. Does not modify the filesystem.
+
+The following keyword arguments are available:
+
+  ``name`` (type: string, required)
+    Full path to the target directory.
+
+  ``mode`` (type: string)
+    Octal permission mode, e.g. ``0755``. Default is ``0755``.
+
+  ``uid`` (type: int)
+    Owner UID. Set to ``0`` to skip ownership changes. Default: ``0``.
+
+  ``gid`` (type: int)
+    Group GID. Set to ``0`` to skip group changes. Default: ``0``.
+
+Examples
+--------
+
+Create ``/etc/myapp/config`` with default permissions:
+
+.. code-block:: yaml
+
+    actions:
+      ensure-config-dir:
+        module: fs.dir
+        bind:
+          - target-host
+        state:
+          $:
+            opts:
+              - present
+            args:
+              name:
+                - /etc/myapp/config
+
+Create a directory with specific mode and ownership:
+
+.. code-block:: yaml
+
+    actions:
+      ensure-data-dir:
+        module: fs.dir
+        bind:
+          - target-host
+        state:
+          $:
+            opts:
+              - present
+            args:
+              name:
+                - /var/lib/myapp/data
+              mode:
+                - "0700"
+              uid:
+                - 1000
+              gid:
+                - 1000
+
+Inspect a directory before deciding:
+
+.. code-block:: yaml
+
+    actions:
+      check-log-dir:
+        module: fs.dir
+        bind:
+          - target-host
+        state:
+          $:
+            opts:
+              - check
+            args:
+              name:
+                - /var/log/myapp
+
+Remove a stale cache directory:
+
+.. code-block:: yaml
+
+    actions:
+      purge-cache:
+        module: fs.dir
+        bind:
+          - target-host
+        state:
+          $:
+            opts:
+              - absent
+            args:
+              name:
+                - /tmp/stale-cache
+
+Dry-run to see what would happen:
+
+.. code-block:: yaml
+
+    actions:
+      preview-dir:
+        module: fs.dir
+        bind:
+          - target-host
+        state:
+          $:
+            opts:
+              - present
+              - dry-run
+            args:
+              name:
+                - /opt/new-service/conf
+
+Returning Data
+--------------
+
+``check``
+  Returns directory metadata:
+
+  .. code-block:: json
+
+      {
+        "retcode": 0,
+        "data": {
+          "name": "/etc/myapp",
+          "exists": true,
+          "is_dir": true,
+          "mode": "0755",
+          "uid": 0,
+          "gid": 0
+        }
+      }
+
+``present``
+  Returns a message describing the action:
+
+  .. code-block:: json
+
+      {
+        "retcode": 0,
+        "message": "Directory created"
+      }
+
+  If the directory already exists with matching attributes:
+
+  .. code-block:: json
+
+      {
+        "retcode": 0,
+        "message": "Directory already exists with matching attributes"
+      }
+
+``absent``
+  Returns a message describing the action:
+
+  .. code-block:: json
+
+      {
+        "retcode": 0,
+        "message": "Directory removed"
+      }
+
+  If the directory was not there:
+
+  .. code-block:: json
+
+      {
+        "retcode": 0,
+        "message": "Directory does not exist"
+      }
+
+``dry-run``
+  Prefixes the message with ``[dry-run]`` without touching disk:
+
+  .. code-block:: json
+
+      {
+        "retcode": 0,
+        "message": "[dry-run] would create"
+      }
+
+.. note::
+
+    The module is idempotent by design. Running ``present`` twice produces no
+    change on the second call. Running ``absent`` on a non-existent directory
+    returns success. The ``dry-run`` flag lets you preview any operation
+    without risk.

--- a/modules/fs/dir/Cargo.toml
+++ b/modules/fs/dir/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dir"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/modules/fs/dir/build.rs
+++ b/modules/fs/dir/build.rs
@@ -1,0 +1,2 @@
+include!("../../build-help.rs");
+fn main() { generate_help(); }

--- a/modules/fs/dir/src/main.rs
+++ b/modules/fs/dir/src/main.rs
@@ -22,9 +22,16 @@ pub extern "C" fn rust_eh_personality() {}
 #[unsafe(no_mangle)]
 pub extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     let mut stdin_buf = [0u8; 512];
+
+    if unsafe { libc::isatty(0) } != 0 {
+        let help = include_bytes!(concat!(env!("OUT_DIR"), "/help.txt"));
+        unsafe { libc::write(1, help.as_ptr() as *const libc::c_void, help.len()) };
+        return 0;
+    }
+
     let n = unsafe { libc::read(0, stdin_buf.as_mut_ptr() as *mut libc::c_void, stdin_buf.len()) };
     if n <= 0 {
-        unsafe { libc::exit(1) };
+        return 1;
     }
     let input = &stdin_buf[..n as usize];
     let mut out = [0u8; 4096];

--- a/modules/fs/dir/src/main.rs
+++ b/modules/fs/dir/src/main.rs
@@ -1,15 +1,24 @@
-#![no_std]
-#![no_main]
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), no_main)]
+#![cfg_attr(test, allow(dead_code))]
 
+#[cfg(not(test))]
 extern crate libc;
 
+#[cfg(not(test))]
 use core::panic::PanicInfo;
 
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     unsafe { libc::exit(1) };
 }
 
+#[cfg(not(test))]
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_eh_personality() {}
+
+#[cfg(not(test))]
 #[unsafe(no_mangle)]
 pub extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     let mut stdin_buf = [0u8; 512];
@@ -83,7 +92,7 @@ fn cstr(bytes: &[u8]) -> [u8; 512] {
 fn check_dir(input: &[u8], out: &mut [u8; 4096]) -> usize {
     let name = get_arg(input, b"name");
     if name.is_empty() {
-        return write_json(out, 1, b"Argument \"name\" is required", b"");
+        return write_json(out, 1, b"Argument 'name' is required", b"");
     }
 
     let path = cstr(name);
@@ -115,7 +124,7 @@ fn check_dir(input: &[u8], out: &mut [u8; 4096]) -> usize {
 fn ensure_present(input: &[u8], out: &mut [u8; 4096]) -> usize {
     let name = get_arg(input, b"name");
     if name.is_empty() {
-        return write_json(out, 1, b"Argument \"name\" is required", b"");
+        return write_json(out, 1, b"Argument 'name' is required", b"");
     }
 
     let mode_arg = get_arg(input, b"mode");
@@ -129,14 +138,8 @@ fn ensure_present(input: &[u8], out: &mut [u8; 4096]) -> usize {
     let exists = unsafe { libc::stat(path.as_ptr() as *const libc::c_char, &mut stat) == 0 };
 
     if dry_run {
-        let mut data = [0u8; 4096];
-        let dp;
-        if exists {
-            dp = wb_str(&mut data, 0, b"already exists");
-        } else {
-            dp = wb_str(&mut data, 0, b"would create");
-        }
-        return write_json(out, 0, b"[dry-run]", &data[..dp]);
+        let msg: &[u8] = if exists { b"[dry-run] already exists" } else { b"[dry-run] would create" };
+        return write_json(out, 0, msg, b"");
     }
 
     if exists {
@@ -171,7 +174,7 @@ fn ensure_present(input: &[u8], out: &mut [u8; 4096]) -> usize {
 fn ensure_absent(input: &[u8], out: &mut [u8; 4096]) -> usize {
     let name = get_arg(input, b"name");
     if name.is_empty() {
-        return write_json(out, 1, b"Argument \"name\" is required", b"");
+        return write_json(out, 1, b"Argument 'name' is required", b"");
     }
 
     let dry_run = has_opt(input, b"dry-run");
@@ -241,10 +244,6 @@ fn wb(out: &mut [u8; 4096], pos: usize, bytes: &[u8]) -> usize {
     }
 }
 
-fn wb_str(out: &mut [u8; 4096], pos: usize, s: &[u8]) -> usize {
-    wb(out, pos, s)
-}
-
 fn wb_u32(out: &mut [u8; 4096], pos: usize, n: u32) -> usize {
     let mut buf = [0u8; 16];
     let mut i = 16;
@@ -262,3 +261,6 @@ fn wb_u32(out: &mut [u8; 4096], pos: usize, n: u32) -> usize {
     out[pos..pos + len].copy_from_slice(&buf[i..]);
     len
 }
+
+#[cfg(test)]
+fn main() {}

--- a/modules/fs/dir/src/main.rs
+++ b/modules/fs/dir/src/main.rs
@@ -114,7 +114,7 @@ fn check_dir(input: &[u8], out: &mut [u8; 4096]) -> usize {
     dp += wb(&mut data_buf, dp, if exists { b"true" } else { b"false" });
     if exists {
         dp += wb(&mut data_buf, dp, b",\"is_dir\":");
-        dp += wb(&mut data_buf, dp, if (stat.st_mode & libc::S_IFDIR as u32) != 0 { b"true" } else { b"false" });
+        dp += wb(&mut data_buf, dp, if (stat.st_mode & libc::S_IFDIR) != 0 { b"true" } else { b"false" });
         dp += wb(&mut data_buf, dp, b",\"mode\":\"");
         let mode = &mut [0u8; 16];
         let mode_str = format_mode(stat.st_mode & 0o777, mode);
@@ -150,7 +150,7 @@ fn ensure_present(input: &[u8], out: &mut [u8; 4096]) -> usize {
     }
 
     if exists {
-        let is_dir = (stat.st_mode & libc::S_IFDIR as u32) != 0;
+        let is_dir = (stat.st_mode & libc::S_IFDIR) != 0;
         if !is_dir {
             return write_json(out, 1, b"Path exists but is not a directory", b"");
         }
@@ -206,7 +206,7 @@ fn ensure_absent(input: &[u8], out: &mut [u8; 4096]) -> usize {
 fn parse_octal(bytes: &[u8]) -> u32 {
     let mut n = 0u32;
     for &b in bytes {
-        if b >= b'0' && b <= b'7' {
+        if (b'0'..=b'7').contains(&b) {
             n = n * 8 + (b - b'0') as u32;
         }
     }

--- a/modules/fs/dir/src/main.rs
+++ b/modules/fs/dir/src/main.rs
@@ -1,0 +1,264 @@
+#![no_std]
+#![no_main]
+
+extern crate libc;
+
+use core::panic::PanicInfo;
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    unsafe { libc::exit(1) };
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+    let mut stdin_buf = [0u8; 512];
+    let n = unsafe { libc::read(0, stdin_buf.as_mut_ptr() as *mut libc::c_void, stdin_buf.len()) };
+    if n <= 0 {
+        unsafe { libc::exit(1) };
+    }
+    let input = &stdin_buf[..n as usize];
+    let mut out = [0u8; 4096];
+    let pos;
+
+    if has_opt(input, b"help") || has_opt(input, b"\"help\"") {
+        let help = include_bytes!(concat!(env!("OUT_DIR"), "/help.txt"));
+        unsafe { libc::write(1, help.as_ptr() as *const libc::c_void, help.len()) };
+        return 0;
+    }
+    if has_opt(input, b"check") {
+        pos = check_dir(input, &mut out);
+    } else if has_opt(input, b"present") {
+        pos = ensure_present(input, &mut out);
+    } else if has_opt(input, b"absent") {
+        pos = ensure_absent(input, &mut out);
+    } else {
+        let msg = b"{\"retcode\":1,\"message\":\"No operation. Use --check, --present, or --absent\"}\n";
+        let len = msg.len();
+        out[..len].copy_from_slice(msg);
+        pos = len;
+    }
+
+    unsafe { libc::write(1, out.as_ptr() as *const libc::c_void, pos) };
+    0
+}
+
+fn has_opt(input: &[u8], name: &[u8]) -> bool {
+    input.windows(name.len()).any(|w| w == name)
+}
+
+fn get_arg<'a>(input: &'a [u8], name: &[u8]) -> &'a [u8] {
+    let mut i = 0usize;
+    while i + name.len() + 3 < input.len() {
+        if input[i] == b'"' && input[i + 1..].starts_with(name) && input[i + 1 + name.len()] == b'"' {
+            let vs = i + name.len() + 4;
+            let mut ve = vs;
+            while ve < input.len() && input[ve] != b'"' {
+                ve += 1;
+            }
+            return &input[vs..ve];
+        }
+        i += 1;
+    }
+    b""
+}
+
+fn parse_u32(bytes: &[u8]) -> u32 {
+    let mut n = 0u32;
+    for &b in bytes {
+        if b.is_ascii_digit() {
+            n = n * 10 + (b - b'0') as u32;
+        }
+    }
+    n
+}
+
+fn cstr(bytes: &[u8]) -> [u8; 512] {
+    let mut buf = [0u8; 512];
+    let len = buf.len().min(bytes.len());
+    buf[..len].copy_from_slice(&bytes[..len]);
+    buf
+}
+
+fn check_dir(input: &[u8], out: &mut [u8; 4096]) -> usize {
+    let name = get_arg(input, b"name");
+    if name.is_empty() {
+        return write_json(out, 1, b"Argument \"name\" is required", b"");
+    }
+
+    let path = cstr(name);
+    let mut stat: libc::stat = unsafe { core::mem::zeroed() };
+    let exists = unsafe { libc::stat(path.as_ptr() as *const libc::c_char, &mut stat) == 0 };
+
+    let mut data_buf = [0u8; 4096];
+    let mut dp = 0usize;
+    dp += wb(&mut data_buf, dp, b"\"name\":\"");
+    dp += wb(&mut data_buf, dp, name);
+    dp += wb(&mut data_buf, dp, b"\",\"exists\":");
+    dp += wb(&mut data_buf, dp, if exists { b"true" } else { b"false" });
+    if exists {
+        dp += wb(&mut data_buf, dp, b",\"is_dir\":");
+        dp += wb(&mut data_buf, dp, if (stat.st_mode & libc::S_IFDIR as u32) != 0 { b"true" } else { b"false" });
+        dp += wb(&mut data_buf, dp, b",\"mode\":\"");
+        let mode = &mut [0u8; 16];
+        let mode_str = format_mode(stat.st_mode & 0o777, mode);
+        dp += wb(&mut data_buf, dp, mode_str);
+        dp += wb(&mut data_buf, dp, b"\",\"uid\":");
+        dp += wb_u32(&mut data_buf, dp, stat.st_uid);
+        dp += wb(&mut data_buf, dp, b",\"gid\":");
+        dp += wb_u32(&mut data_buf, dp, stat.st_gid);
+    }
+
+    write_json(out, 0, b"", &data_buf[..dp])
+}
+
+fn ensure_present(input: &[u8], out: &mut [u8; 4096]) -> usize {
+    let name = get_arg(input, b"name");
+    if name.is_empty() {
+        return write_json(out, 1, b"Argument \"name\" is required", b"");
+    }
+
+    let mode_arg = get_arg(input, b"mode");
+    let mode = if mode_arg.len() >= 3 { parse_octal(mode_arg) } else { 0o755 };
+    let uid = parse_u32(get_arg(input, b"uid"));
+    let gid = parse_u32(get_arg(input, b"gid"));
+    let dry_run = has_opt(input, b"dry-run");
+
+    let path = cstr(name);
+    let mut stat: libc::stat = unsafe { core::mem::zeroed() };
+    let exists = unsafe { libc::stat(path.as_ptr() as *const libc::c_char, &mut stat) == 0 };
+
+    if dry_run {
+        let mut data = [0u8; 4096];
+        let dp;
+        if exists {
+            dp = wb_str(&mut data, 0, b"already exists");
+        } else {
+            dp = wb_str(&mut data, 0, b"would create");
+        }
+        return write_json(out, 0, b"[dry-run]", &data[..dp]);
+    }
+
+    if exists {
+        let is_dir = (stat.st_mode & libc::S_IFDIR as u32) != 0;
+        if !is_dir {
+            return write_json(out, 1, b"Path exists but is not a directory", b"");
+        }
+        let mode_ok = (stat.st_mode & 0o777) == mode;
+        let owner_ok = (uid == 0 || stat.st_uid == uid) && (gid == 0 || stat.st_gid == gid);
+        if mode_ok && owner_ok {
+            return write_json(out, 0, b"Directory already exists with matching attributes", b"");
+        }
+        if uid > 0 || gid > 0 {
+            unsafe { libc::chown(path.as_ptr() as *const libc::c_char, uid, gid) };
+        }
+        if (stat.st_mode & 0o777) != mode {
+            unsafe { libc::chmod(path.as_ptr() as *const libc::c_char, mode) };
+        }
+        return write_json(out, 0, b"Directory attributes updated", b"");
+    }
+
+    let ret = unsafe { libc::mkdir(path.as_ptr() as *const libc::c_char, mode) };
+    if ret != 0 {
+        return write_json(out, 1, b"Failed to create directory", b"");
+    }
+    if uid > 0 || gid > 0 {
+        unsafe { libc::chown(path.as_ptr() as *const libc::c_char, uid, gid) };
+    }
+    write_json(out, 0, b"Directory created", b"")
+}
+
+fn ensure_absent(input: &[u8], out: &mut [u8; 4096]) -> usize {
+    let name = get_arg(input, b"name");
+    if name.is_empty() {
+        return write_json(out, 1, b"Argument \"name\" is required", b"");
+    }
+
+    let dry_run = has_opt(input, b"dry-run");
+    let path = cstr(name);
+    let mut stat: libc::stat = unsafe { core::mem::zeroed() };
+    let exists = unsafe { libc::stat(path.as_ptr() as *const libc::c_char, &mut stat) == 0 };
+
+    if !exists {
+        return write_json(out, 0, b"Directory does not exist", b"");
+    }
+    if dry_run {
+        return write_json(out, 0, b"[dry-run] would remove directory", b"");
+    }
+
+    let ret = unsafe { libc::rmdir(path.as_ptr() as *const libc::c_char) };
+    if ret != 0 {
+        return write_json(out, 1, b"Failed to remove directory", b"");
+    }
+    write_json(out, 0, b"Directory removed", b"")
+}
+
+fn parse_octal(bytes: &[u8]) -> u32 {
+    let mut n = 0u32;
+    for &b in bytes {
+        if b >= b'0' && b <= b'7' {
+            n = n * 8 + (b - b'0') as u32;
+        }
+    }
+    n
+}
+
+fn format_mode(mode: u32, buf: &mut [u8; 16]) -> &[u8] {
+    let s = &mut [0u8; 5];
+    s[0] = b'0';
+    s[1] = b'0' + ((mode >> 6) & 7) as u8;
+    s[2] = b'0' + ((mode >> 3) & 7) as u8;
+    s[3] = b'0' + (mode & 7) as u8;
+    buf[..4].copy_from_slice(&s[..4]);
+    &buf[..4]
+}
+
+fn write_json(out: &mut [u8; 4096], retcode: i32, msg: &[u8], data: &[u8]) -> usize {
+    let mut p = 0usize;
+    p += wb(out, p, b"{\"retcode\":");
+    p += wb_u32(out, p, retcode as u32);
+    if !msg.is_empty() {
+        p += wb(out, p, b",\"message\":\"");
+        p += wb(out, p, msg);
+        p += wb(out, p, b"\"");
+    }
+    if !data.is_empty() {
+        p += wb(out, p, b",\"data\":{");
+        p += wb(out, p, data);
+        p += wb(out, p, b"}");
+    }
+    p += wb(out, p, b"}\n");
+    p
+}
+
+fn wb(out: &mut [u8; 4096], pos: usize, bytes: &[u8]) -> usize {
+    let n = bytes.len();
+    if pos + n < out.len() {
+        out[pos..pos + n].copy_from_slice(bytes);
+        n
+    } else {
+        0
+    }
+}
+
+fn wb_str(out: &mut [u8; 4096], pos: usize, s: &[u8]) -> usize {
+    wb(out, pos, s)
+}
+
+fn wb_u32(out: &mut [u8; 4096], pos: usize, n: u32) -> usize {
+    let mut buf = [0u8; 16];
+    let mut i = 16;
+    if n == 0 {
+        out[pos] = b'0';
+        return 1;
+    }
+    let mut v = n;
+    while v > 0 && i > 0 {
+        i -= 1;
+        buf[i] = b'0' + (v % 10) as u8;
+        v /= 10;
+    }
+    let len = 16 - i;
+    out[pos..pos + len].copy_from_slice(&buf[i..]);
+    len
+}

--- a/modules/fs/dir/src/mod_doc.yaml
+++ b/modules/fs/dir/src/mod_doc.yaml
@@ -1,0 +1,111 @@
+name: "fs.dir"
+version: "0.1.0"
+author: "Bo Maryniuk"
+description: |
+  Directory state management module. Ensure directories exist, inspect
+  their attributes, and remove them. Idempotent and allocation-free.
+
+options:
+  - name: check
+    description: "Inspect directory state (exists, mode, uid, gid)"
+
+  - name: present
+    description: "Ensure directory exists with given attributes"
+
+  - name: absent
+    description: "Remove directory if it exists"
+
+  - name: dry-run
+    description: "Print what would be done without making changes"
+
+  - name: help
+    description: "Show this help message"
+
+arguments:
+  - name: name
+    type: "string"
+    required: true
+    description: "Directory path"
+
+  - name: mode
+    type: "string"
+    required: false
+    description: "Octal mode for directory (default: 0755)"
+
+  - name: uid
+    type: "int"
+    required: false
+    description: "Owner UID (0 = skip)"
+
+  - name: gid
+    type: "int"
+    required: false
+    description: "Group GID (0 = skip)"
+
+examples:
+  - description: "Create /etc/myapp/config with default mode"
+    code: |
+      "options": ["present"],
+      "arguments": {
+        "name": "/etc/myapp/config"
+      }
+
+  - description: "Create directory with specific mode and owner"
+    code: |
+      "options": ["present"],
+      "arguments": {
+        "name": "/var/lib/data",
+        "mode": "0700",
+        "uid": 1000,
+        "gid": 1000
+      }
+
+  - description: "Inspect a directory"
+    code: |
+      "options": ["check"],
+      "arguments": {
+        "name": "/etc/myapp/config"
+      }
+
+  - description: "Remove a directory"
+    code: |
+      "options": ["absent"],
+      "arguments": {
+        "name": "/tmp/stale-cache"
+      }
+
+returns:
+  check:
+    :description: "Directory state inspection result"
+    retcode: 0
+    data:
+      name: "/etc/myapp"
+      exists: true
+      is_dir: true
+      mode: "0755"
+      uid: 0
+      gid: 0
+
+  present:
+    :description: "Creation or attribute update result"
+    retcode: 0
+    message: "Directory created"
+
+  absent:
+    :description: "Removal result"
+    retcode: 0
+    message: "Directory removed"
+
+manpage: |
+  This module manages directory state through three operations:
+
+  - [B::]check[N]: inspect a directory's existence, type, mode, owner, and group.
+  - [B::]present[N]: ensure a directory exists with the given attributes.
+    If it already exists, mode and ownership are updated if they differ.
+  - [B::]absent[N]: remove a directory if it exists.
+
+  All operations are idempotent. [B::]dry-run[N] prints what would happen
+  without making changes.
+
+  This module is [G::]#![no_std][N] and makes no heap allocations — only raw
+  libc calls, suitable for minimal environments.

--- a/modules/fs/dir/tests/runtime_call.rs
+++ b/modules/fs/dir/tests/runtime_call.rs
@@ -1,0 +1,226 @@
+use serde_json::{Value, json};
+use std::{
+    fs,
+    io::Write,
+    os::unix::fs::PermissionsExt,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+fn bin_path() -> PathBuf {
+    if let Ok(p) = std::env::var("CARGO_BIN_EXE_dir") {
+        return PathBuf::from(p);
+    }
+    let mut p = std::env::current_exe().expect("cannot locate test executable");
+    p.pop();
+    p.pop();
+    p.push("dir");
+    assert!(p.exists(), "dir binary not found at {}", p.display());
+    p
+}
+
+fn run_module(payload: &Value) -> Value {
+    let bin = bin_path();
+    let mut child = Command::new(&bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|err| panic!("failed to spawn {} binary: {}", bin.display(), err));
+
+    child
+        .stdin
+        .as_mut()
+        .expect("dir stdin is not available")
+        .write_all(payload.to_string().as_bytes())
+        .expect("failed to write module request payload");
+
+    let out = child.wait_with_output().expect("failed to wait for dir output");
+    assert!(out.status.success(), "dir exited with status {}", out.status);
+
+    serde_json::from_slice(&out.stdout).expect("failed to parse dir JSON output")
+}
+
+fn tmpdir() -> String {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static CNT: AtomicU32 = AtomicU32::new(0);
+    let n = CNT.fetch_add(1, Ordering::Relaxed);
+    let d = format!("/tmp/dir-test-{}-{}", std::process::id(), n);
+    let _ = fs::remove_dir_all(&d);
+    d
+}
+
+// -------- check --------
+
+#[test]
+fn check_existing_directory() {
+    let out = run_module(&json!({
+        "options": ["check"],
+        "arguments": { "name": "/tmp" }
+    }));
+    assert_eq!(out["retcode"], 0);
+    assert_eq!(out["data"]["name"], "/tmp");
+    assert_eq!(out["data"]["exists"], true);
+    assert_eq!(out["data"]["is_dir"], true);
+}
+
+#[test]
+fn check_nonexistent_directory() {
+    let d = tmpdir();
+    let out = run_module(&json!({
+        "options": ["check"],
+        "arguments": { "name": d }
+    }));
+    assert_eq!(out["retcode"], 0);
+    assert_eq!(out["data"]["name"], d);
+    assert_eq!(out["data"]["exists"], false);
+}
+
+#[test]
+fn check_missing_name_returns_error() {
+    let out = run_module(&json!({
+        "options": ["check"],
+        "arguments": {}
+    }));
+    assert_eq!(out["retcode"], 1);
+    assert!(out["message"].as_str().unwrap().contains("name"));
+}
+
+// -------- present --------
+
+#[test]
+fn present_creates_directory() {
+    let d = tmpdir();
+    let out = run_module(&json!({
+        "options": ["present"],
+        "arguments": { "name": d }
+    }));
+    assert_eq!(out["retcode"], 0);
+    assert!(fs::metadata(&d).unwrap().is_dir());
+    fs::remove_dir(&d).unwrap();
+}
+
+#[test]
+fn present_idempotent_existing_directory() {
+    let d = tmpdir();
+    fs::create_dir(&d).unwrap();
+    let out = run_module(&json!({
+        "options": ["present"],
+        "arguments": { "name": d, "mode": "0775" }
+    }));
+    assert_eq!(out["retcode"], 0);
+    assert!(out["message"].as_str().unwrap().contains("already exists"));
+    fs::remove_dir(&d).unwrap();
+}
+
+#[test]
+fn present_with_mode() {
+    let d = tmpdir();
+    let out = run_module(&json!({
+        "options": ["present"],
+        "arguments": { "name": d, "mode": "0700" }
+    }));
+    assert_eq!(out["retcode"], 0);
+    let meta = fs::metadata(&d).unwrap();
+    let mode = meta.permissions().mode() & 0o777;
+    assert_eq!(mode, 0o700);
+    fs::remove_dir(&d).unwrap();
+}
+
+#[test]
+fn present_missing_name_returns_error() {
+    let out = run_module(&json!({
+        "options": ["present"],
+        "arguments": {}
+    }));
+    assert_eq!(out["retcode"], 1);
+    assert!(out["message"].as_str().unwrap().contains("name"));
+}
+
+// -------- absent --------
+
+#[test]
+fn absent_removes_directory() {
+    let d = tmpdir();
+    fs::create_dir(&d).unwrap();
+    let out = run_module(&json!({
+        "options": ["absent"],
+        "arguments": { "name": d }
+    }));
+    assert_eq!(out["retcode"], 0);
+    assert!(!fs::metadata(&d).is_ok());
+}
+
+#[test]
+fn absent_idempotent_nonexistent() {
+    let d = tmpdir();
+    let out = run_module(&json!({
+        "options": ["absent"],
+        "arguments": { "name": d }
+    }));
+    assert_eq!(out["retcode"], 0);
+    assert!(out["message"].as_str().unwrap().contains("does not exist"));
+}
+
+#[test]
+fn absent_missing_name_returns_error() {
+    let out = run_module(&json!({
+        "options": ["absent"],
+        "arguments": {}
+    }));
+    assert_eq!(out["retcode"], 1);
+    assert!(out["message"].as_str().unwrap().contains("name"));
+}
+
+// -------- dry-run --------
+
+#[test]
+fn dry_run_present_shows_would_create() {
+    let d = tmpdir();
+    let out = run_module(&json!({
+        "options": ["present", "dry-run"],
+        "arguments": { "name": d }
+    }));
+    assert_eq!(out["retcode"], 0);
+    assert!(out["message"].as_str().unwrap().contains("[dry-run]"));
+    assert!(out["message"].as_str().unwrap().contains("would create"));
+    assert!(!fs::metadata(&d).is_ok());
+}
+
+#[test]
+fn dry_run_present_shows_already_exists() {
+    let d = tmpdir();
+    fs::create_dir(&d).unwrap();
+    let out = run_module(&json!({
+        "options": ["present", "dry-run"],
+        "arguments": { "name": d }
+    }));
+    assert_eq!(out["retcode"], 0);
+    assert!(out["message"].as_str().unwrap().contains("already exists"));
+    fs::remove_dir(&d).unwrap();
+}
+
+#[test]
+fn dry_run_absent_shows_would_remove() {
+    let d = tmpdir();
+    fs::create_dir(&d).unwrap();
+    let out = run_module(&json!({
+        "options": ["absent", "dry-run"],
+        "arguments": { "name": d }
+    }));
+    assert_eq!(out["retcode"], 0);
+    assert!(out["message"].as_str().unwrap().contains("would remove"));
+    assert!(fs::metadata(&d).unwrap().is_dir());
+    fs::remove_dir(&d).unwrap();
+}
+
+// -------- validation --------
+
+#[test]
+fn no_operation_returns_error() {
+    let out = run_module(&json!({
+        "options": [],
+        "arguments": {}
+    }));
+    assert_eq!(out["retcode"], 1);
+    assert!(out["message"].as_str().unwrap().contains("No operation"));
+}

--- a/modules/fs/dir/tests/runtime_call.rs
+++ b/modules/fs/dir/tests/runtime_call.rs
@@ -103,9 +103,10 @@ fn present_creates_directory() {
 fn present_idempotent_existing_directory() {
     let d = tmpdir();
     fs::create_dir(&d).unwrap();
+    let actual_mode = format!("{:04o}", fs::metadata(&d).unwrap().permissions().mode() & 0o777);
     let out = run_module(&json!({
         "options": ["present"],
-        "arguments": { "name": d, "mode": "0775" }
+        "arguments": { "name": d.as_str(), "mode": actual_mode }
     }));
     assert_eq!(out["retcode"], 0);
     assert!(out["message"].as_str().unwrap().contains("already exists"));


### PR DESCRIPTION
Adds `fs.dir` module to manage directories. This one specifically is an example of minimalistic binary that compiles on x86_64 to only 14K.

- [x] Implementation
- [x] Documentation
- [x] Tests