### PR TITLE
Add journaled networking

### DIFF
--- a/docs/global_config.rst
+++ b/docs/global_config.rst
@@ -936,6 +936,33 @@ and contains the following directives:
 
     Default is ``true``
 
+``journal.path``
+################
+
+    Type: **string**
+
+    Path to the persistent outgoing journal directory. The journal buffers
+    model/event results on disk before transmission to the master so that no
+    data is lost when the network connection drops. Each record stays in the
+    journal until the master acknowledges the cycle it belongs to.
+
+    Default: ``<managed_db_dir>/journal``, which resolves to ``/tmp/journal``
+    on a system-layout install and ``<root>/tmp/journal`` on a custom-layout
+    install.
+
+``journal.size``
+################
+
+    Type: **string / integer**
+
+    Maximum total size of the outgoing journal in bytes. Accepts plain
+    integers or human-readable strings with an optional unit suffix
+    (``B``, ``KB``, ``MB``, ``GB``, ``TB``). When the un-acked data exceeds
+    this budget the oldest cycle is evicted automatically. Set to ``0`` to
+    disable the budget entirely (unlimited).
+
+    Default: ``64 MiB``.
+
 
 Example configuration for the Sysinspect Minion:
 
@@ -948,6 +975,10 @@ Example configuration for the Sysinspect Minion:
             root: /etc/sysinspect
             master.ip: 192.168.2.31
             master.port: 4200
+
+            # Outgoing journal (defaults shown):
+            # journal.path: /tmp/journal
+            # journal.size: 64 MiB
 
 Layout of ``/etc/sysinspect``
 -----------------------------

--- a/docs/global_config.rst
+++ b/docs/global_config.rst
@@ -946,6 +946,18 @@ and contains the following directives:
     data is lost when the network connection drops. Each record stays in the
     journal until the master acknowledges the cycle it belongs to.
 
+    The journal is part of the Minion's durable delivery path:
+
+    - action callbacks (``Event``) are written before network send
+    - final model callbacks (``ModelEvent``) are written before network send
+    - model completion notices (``ModelAck``) are written before network send
+    - on reconnect, any still-pending records are replayed to the Master
+    - a cycle is freed only after the Master sends ``CycleAck``
+
+    This means the delivery model is intentionally **at-least-once**. Replay can
+    cause the same payload to be sent again after reconnect or restart, and the
+    Master is expected to handle that safely.
+
     Default: ``<managed_db_dir>/journal``, which resolves to ``/tmp/journal``
     on a system-layout install and ``<root>/tmp/journal`` on a custom-layout
     install.
@@ -961,7 +973,56 @@ and contains the following directives:
     this budget the oldest cycle is evicted automatically. Set to ``0`` to
     disable the budget entirely (unlimited).
 
+    .. warning::
+
+        Journal eviction is a durability boundary. If the Minion stays offline
+        long enough to exceed this budget, the oldest un-acknowledged cycle is
+        dropped to protect local storage. Sysinspect logs a warning when this
+        happens.
+
     Default: ``64 MiB``.
+
+Journaled delivery model
+########################
+
+The outgoing journal is not just a cache directory. It is the Minion's durable
+network-delivery ledger.
+
+Result traffic that is persisted and replayed:
+
+- ``Event``
+- ``ModelEvent``
+- ``ModelAck``
+
+Session/control traffic that is not persisted in the journal:
+
+- ``Ehlo``
+- ``Traits``
+- ``Ping`` / ``Pong``
+- sensor sync requests/responses
+- ``Bye`` and other session-management messages
+
+The design intentionally separates **local execution** from **result delivery**:
+
+- local work may finish even if the Master is temporarily unavailable
+- result messages stay in the journal until the Master confirms the cycle
+- reconnect or restart replays any still-pending result traffic
+
+When a cycle completes locally, the Minion also records a durable local
+completion marker. This marker exists so that after a hard restart, the Minion
+can distinguish:
+
+- work that never finished locally and must be executed again
+- work that already finished locally and only needs result replay/delivery
+
+As a result, hard restart recovery follows these rules:
+
+- if a cycle had not yet reached durable local completion, rerun is expected
+- if a cycle had already reached durable local completion, local re-execution is
+  skipped and only journal replay is used to finish delivery
+
+This model is designed for unreliable networks where the Master may disappear
+temporarily, but the Minion must still converge and later flush its results.
 
 
 Example configuration for the Sysinspect Minion:

--- a/libdpq/src/lib.rs
+++ b/libdpq/src/lib.rs
@@ -281,9 +281,9 @@ impl DiskPersistentQueue {
     /// Recovery on startup: move all inflight items back to pending, so they can be retried.
     /// This is needed in case the process was killed while processing some jobs, to avoid losing them.
     ///
-    /// Note: this is a simple recovery mechanism that does not guarantee exactly-once processing,
-    ///       but it is sufficient for many use cases. For more advanced scenarios, consider adding
-    ///       timestamps and retry limits to the inflight items.
+    /// Note: this does not guarantee exactly-once execution by itself. Sysminion layers its own
+    ///       durable "local execution completed" marker on top so recovered jobs can be skipped
+    ///       once execution finished locally and only delivery recovery remains.
     ///
     /// Returns an error if the recovery process fails, or Ok(()) if it succeeds.
     ///

--- a/libdpq/src/lib.rs
+++ b/libdpq/src/lib.rs
@@ -5,6 +5,9 @@ use sled::{Db, IVec, Tree};
 use std::{path::Path, sync::Arc, time::Duration};
 use tokio::sync::mpsc;
 
+#[cfg(test)]
+mod lib_ut;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WorkItem {
     MasterCommand(MasterMessage),
@@ -17,7 +20,7 @@ pub enum WorkItem {
 /// It also has a recovery mechanism to move inflight jobs back to pending on startup, in case the process was killed while processing some jobs.
 /// Note: this implementation does not have features like delayed retries, dead-letter queues, or visibility timeouts, but it can be extended with those if needed.
 /// Example usage:
-/// ```
+/// ```text
 /// let q = DiskPersistentQueue::open("/path/to/queue")?;
 /// let item = WorkItem::MasterCommand(...);
 /// let job_id = q.add(item)?;
@@ -50,9 +53,9 @@ impl DiskPersistentQueue {
     /// It will also perform recovery by moving any inflight jobs back to pending, so they can be retried.
     /// Returns a DiskPersistentQueue instance on success, or an error if the database cannot be opened or initialized.
     /// Example usage:
-    /// ```
+    /// ```text
     /// let q = DiskPersistentQueue::open("/path/to/queue")?;
-    /// ```
+    /// ```text
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, SysinspectError> {
         let db = Arc::new(sled::open(path)?);
 
@@ -94,10 +97,10 @@ impl DiskPersistentQueue {
     /// Returns the next job ID on success, or an error if the operation fails.
     ///
     /// Example usage:
-    /// ```
+    /// ```text
     /// let job_id = q.next_id()?;
     /// println!("Next job ID: {job_id}");
-    /// ```
+    /// ```text
     fn next_id(&self) -> Result<u64, SysinspectError> {
         let key = b"next_id";
         let old = self.meta.fetch_and_update(key, |old| {
@@ -119,10 +122,10 @@ impl DiskPersistentQueue {
     /// Returns an error if the storage process fails, or Ok(()) if it succeeds.
     ///
     /// Example usage:
-    /// ```
+    /// ```text
     /// let item = WorkItem::MasterCommand(...);
     /// q.store_task(job_id, &item).unwrap();
-    /// ```
+    /// ```text
     fn store_task(&self, id: u64, item: &WorkItem) -> Result<(), SysinspectError> {
         let key = Self::u64_key(id);
         let val = serde_json::to_vec(item)?;
@@ -134,7 +137,7 @@ impl DiskPersistentQueue {
     /// Returns Ok(Some(WorkItem)) if the task is found and deserialized successfully,
     /// Ok(None) if the task is not found, or Err if there is an error during the process.
     /// Example usage:
-    /// ```
+    /// ```text
     /// match q.load_task(job_id) {
     ///     Ok(Some(item)) => {
     ///         // Process the item...
@@ -146,7 +149,7 @@ impl DiskPersistentQueue {
     ///         eprintln!("Error loading task with ID {job_id}: {e}");
     ///     }
     /// }
-    /// ```
+    /// ```text
     fn load_task(&self, id: u64) -> Result<Option<WorkItem>, SysinspectError> {
         let key = Self::u64_key(id);
         let Some(v) = self.jobs.get(key)? else {
@@ -157,11 +160,11 @@ impl DiskPersistentQueue {
 
     /// Add a new job to the queue. Returns the assigned job ID on success.
     /// Example usage:
-    /// ```
+    /// ```text
     /// let item = WorkItem::MasterCommand(...);
     /// let job_id = q.add(item).unwrap();
     /// println!("Enqueued job with ID: {job_id}");
-    /// ```
+    /// ```text
     pub fn add(&self, item: WorkItem) -> Result<u64, SysinspectError> {
         let id = self.next_id()?;
         self.store_task(id, &item)?;
@@ -176,7 +179,7 @@ impl DiskPersistentQueue {
     /// Returns Ok(Some((id, item))) if a job is available, Ok(None) if no jobs are pending, or Err if there is an error during the process.
     /// The caller should call ack(id) when the job is done, or nack(id) if it fails and should be retried.
     /// Example usage:
-    /// ```
+    /// ```text
     /// match q.fetch() {
     ///     Ok(Some((id, item))) => {
     ///         // Process the item...
@@ -228,7 +231,7 @@ impl DiskPersistentQueue {
     ///
     /// Returns an error if the ack process fails, or Ok(()) if it succeeds.
     /// Example usage:
-    /// ```
+    /// ```text
     /// if let Err(e) = q.ack(job_id) {
     ///     eprintln!("Ack failed for {job_id}: {e}");
     /// }
@@ -248,7 +251,7 @@ impl DiskPersistentQueue {
     /// Returns an error if the nack process fails, or Ok(()) if it succeeds.
     ///
     /// Example usage:
-    /// ```
+    /// ```text
     /// if let Err(e) = q.nack(job_id) {
     ///     eprintln!("Nack failed for {job_id}: {e}");
     /// }
@@ -273,10 +276,10 @@ impl DiskPersistentQueue {
     ///       manually in normal operation.
     ///
     /// Example usage:
-    /// ```
+    /// ```text
     /// let q = DiskPersistentQueue::open("/path/to/queue")?;
     /// q.recover()?;
-    /// ```
+    /// ```text
     pub fn recover(&self) -> Result<(), SysinspectError> {
         let keys: Vec<[u8; 8]> = self
             .inflight
@@ -313,7 +316,7 @@ impl DiskPersistentQueue {
     /// This is a convenience method that wraps the start_ack() method, but does not handle nacking for you.
     ///
     /// Example usage:
-    /// ```
+    /// ```text
     /// q.start(|job_id, item| async move {
     ///     // Process the item...
     ///     // Then ack or nack:
@@ -342,7 +345,7 @@ impl DiskPersistentQueue {
     /// and should return a Future that completes with a Result indicating whether the job was successful or not.
     ///
     /// Example usage:
-    /// ```
+    /// ```text
     /// q.start_ack(|job_id, item| async move {
     ///     // Process the item...
     ///     // Return Ok(()) if successful, or Err(e) if failed:
@@ -353,7 +356,7 @@ impl DiskPersistentQueue {
     ///     }
     /// });
     /// ```
-    pub fn start_ack<F, Fut>(&self, mut exec: F) -> tokio::task::JoinHandle<()>
+pub fn start_ack<F, Fut>(&self, mut exec: F) -> tokio::task::JoinHandle<()>
     where
         F: FnMut(u64, WorkItem) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<(), SysinspectError>> + Send + 'static,

--- a/libdpq/src/lib.rs
+++ b/libdpq/src/lib.rs
@@ -47,6 +47,18 @@ pub struct DiskPersistentQueue {
     tx: mpsc::Sender<()>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct QueueStats {
+    pub pending_jobs: usize,
+    pub inflight_jobs: usize,
+}
+
+impl QueueStats {
+    pub fn format(self) -> String {
+        format!("{}/{} pending/inflight", self.pending_jobs, self.inflight_jobs)
+    }
+}
+
 impl DiskPersistentQueue {
     /// Open or create a new disk-backed queue at the specified path.
     /// This will create the necessary sled database and trees if they don't exist.
@@ -66,7 +78,10 @@ impl DiskPersistentQueue {
 
         let (tx, _rx) = mpsc::channel::<()>(1);
         let q = Self { db, meta, pending, inflight, jobs, tx };
-        q.recover()?;
+        let recovered = q.recover()?;
+        if recovered > 0 {
+            log::warn!("Recovered {} inflight DPQ job(s) back to pending on startup", recovered);
+        }
 
         // Wake up any runners waiting for jobs
         let _ = q.tx.try_send(());
@@ -280,7 +295,7 @@ impl DiskPersistentQueue {
     /// let q = DiskPersistentQueue::open("/path/to/queue")?;
     /// q.recover()?;
     /// ```text
-    pub fn recover(&self) -> Result<(), SysinspectError> {
+    pub fn recover(&self) -> Result<usize, SysinspectError> {
         let keys: Vec<[u8; 8]> = self
             .inflight
             .iter()
@@ -306,7 +321,12 @@ impl DiskPersistentQueue {
             self.db.flush()?;
         }
 
-        Ok(())
+        Ok(keys.len())
+    }
+
+    /// Return current queue backlog counters for operator visibility.
+    pub fn stats(&self) -> QueueStats {
+        QueueStats { pending_jobs: self.pending.len(), inflight_jobs: self.inflight.len() }
     }
 
     /// Start a runner that continuously tries to dequeue and execute jobs using the provided async closure.

--- a/libdpq/src/lib.rs
+++ b/libdpq/src/lib.rs
@@ -356,7 +356,7 @@ impl DiskPersistentQueue {
     ///     }
     /// });
     /// ```
-pub fn start_ack<F, Fut>(&self, mut exec: F) -> tokio::task::JoinHandle<()>
+    pub fn start_ack<F, Fut>(&self, mut exec: F) -> tokio::task::JoinHandle<()>
     where
         F: FnMut(u64, WorkItem) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<(), SysinspectError>> + Send + 'static,

--- a/libdpq/src/lib_ut.rs
+++ b/libdpq/src/lib_ut.rs
@@ -133,3 +133,24 @@ async fn aborting_runner_leaves_job_recoverable_on_reopen() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn stats_report_pending_and_inflight_jobs() {
+    let dir = temp_dir("stats");
+    let q = DiskPersistentQueue::open(&dir).unwrap();
+    let id1 = q.add(work_item()).unwrap();
+    let _id2 = q.add(work_item()).unwrap();
+
+    let stats = q.stats();
+    assert_eq!(stats.pending_jobs, 2);
+    assert_eq!(stats.inflight_jobs, 0);
+
+    let fetched = q.fetch().unwrap();
+    assert!(matches!(fetched, Some((job_id, _)) if job_id == id1));
+
+    let stats = q.stats();
+    assert_eq!(stats.pending_jobs, 1);
+    assert_eq!(stats.inflight_jobs, 1);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/libdpq/src/lib_ut.rs
+++ b/libdpq/src/lib_ut.rs
@@ -1,0 +1,135 @@
+use crate::{DiskPersistentQueue, WorkItem};
+use libsysproto::{MasterMessage, rqtypes::RequestType};
+use serde_json::json;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use tokio::sync::oneshot;
+use tokio::time::{Duration, timeout};
+
+fn temp_dir(label: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "libdpq-{}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos(),
+        label
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn work_item() -> WorkItem {
+    WorkItem::MasterCommand(MasterMessage::new(RequestType::Command, json!({"uri": "model://test"})))
+}
+
+#[test]
+fn fetch_moves_job_to_inflight_and_ack_clears_it() {
+    let dir = temp_dir("fetch-ack");
+    let q = DiskPersistentQueue::open(&dir).unwrap();
+    let id = q.add(work_item()).unwrap();
+
+    let fetched = q.fetch().unwrap();
+    assert!(matches!(fetched, Some((job_id, _)) if job_id == id));
+    assert!(q.pending.is_empty());
+    assert_eq!(q.inflight.len(), 1);
+    assert_eq!(q.jobs.len(), 1);
+
+    q.ack(id).unwrap();
+    assert!(q.pending.is_empty());
+    assert!(q.inflight.is_empty());
+    assert!(q.jobs.is_empty());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn reopen_recovers_inflight_job_back_to_pending() {
+    let dir = temp_dir("recover-inflight");
+    let id = {
+        let q = DiskPersistentQueue::open(&dir).unwrap();
+        let id = q.add(work_item()).unwrap();
+        let fetched = q.fetch().unwrap();
+        assert!(matches!(fetched, Some((job_id, _)) if job_id == id));
+        assert!(q.pending.is_empty());
+        assert_eq!(q.inflight.len(), 1);
+        id
+    };
+
+    let q = DiskPersistentQueue::open(&dir).unwrap();
+    assert_eq!(q.pending.len(), 1);
+    assert!(q.inflight.is_empty());
+    assert_eq!(q.jobs.len(), 1);
+    let fetched = q.fetch().unwrap();
+    assert!(matches!(fetched, Some((job_id, _)) if job_id == id));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn reopen_after_ack_does_not_requeue_completed_job() {
+    let dir = temp_dir("reopen-acked");
+    {
+        let q = DiskPersistentQueue::open(&dir).unwrap();
+        let id = q.add(work_item()).unwrap();
+        let fetched = q.fetch().unwrap();
+        assert!(matches!(fetched, Some((job_id, _)) if job_id == id));
+        q.ack(id).unwrap();
+    }
+
+    let q = DiskPersistentQueue::open(&dir).unwrap();
+    assert!(q.pending.is_empty());
+    assert!(q.inflight.is_empty());
+    assert!(q.jobs.is_empty());
+    assert!(q.fetch().unwrap().is_none());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn aborting_runner_leaves_job_recoverable_on_reopen() {
+    let dir = temp_dir("abort-recover");
+    let q = DiskPersistentQueue::open(&dir).unwrap();
+    let id = q.add(work_item()).unwrap();
+
+    let started = Arc::new(AtomicBool::new(false));
+    let (hold_tx, hold_rx) = oneshot::channel::<()>();
+    let hold_rx = Arc::new(tokio::sync::Mutex::new(Some(hold_rx)));
+
+    let runner = q.start_ack({
+        let started = Arc::clone(&started);
+        let hold_rx = Arc::clone(&hold_rx);
+        move |_job_id, _item| {
+            let started = Arc::clone(&started);
+            let hold_rx = Arc::clone(&hold_rx);
+            async move {
+                started.store(true, Ordering::Relaxed);
+                if let Some(rx) = hold_rx.lock().await.take() {
+                    let _ = rx.await;
+                }
+                Ok(())
+            }
+        }
+    });
+
+    timeout(Duration::from_secs(2), async {
+        while !started.load(Ordering::Relaxed) {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("runner never started processing job");
+
+    runner.abort();
+    let _ = runner.await;
+    drop(hold_tx);
+    drop(q);
+
+    let q = DiskPersistentQueue::open(&dir).unwrap();
+    assert_eq!(q.pending.len(), 1);
+    assert!(q.inflight.is_empty());
+    let fetched = q.fetch().unwrap();
+    assert!(matches!(fetched, Some((job_id, _)) if job_id == id));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/libeventreg/src/ipcs.rs
+++ b/libeventreg/src/ipcs.rs
@@ -103,6 +103,11 @@ impl DbIPCService {
         self.evtreg.lock().await.add_event(sid, mid, payload)
     }
 
+    /// Claim a replay key. Returns true only for the first successful claim.
+    pub async fn claim_replay_key(&self, key: &str) -> Result<bool, SysinspectError> {
+        self.evtreg.lock().await.claim_replay_key(key)
+    }
+
     /// Get sessions
     pub async fn get_sessions(&self) -> Result<Vec<EventSession>, SysinspectError> {
         self.evtreg.lock().await.get_sessions()

--- a/libeventreg/src/kvdb.rs
+++ b/libeventreg/src/kvdb.rs
@@ -15,6 +15,7 @@ use std::{collections::HashMap, fmt::Debug, fs, path::PathBuf, sync::Mutex};
 use tempfile::Builder;
 
 const TR_SESSIONS: &str = "sessions";
+const TR_REPLAY: &str = "replay";
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct EventData {
@@ -293,6 +294,16 @@ impl EventsRegistry {
         } else {
             Ok(())
         }
+    }
+
+    /// Claim a replay key. Returns true only for the first successful claim.
+    pub fn claim_replay_key(&self, key: &str) -> Result<bool, SysinspectError> {
+        let replay = self.get_tree(TR_REPLAY)?;
+        if replay.contains_key(key)? {
+            return Ok(false);
+        }
+        replay.insert(key, &[][..])?;
+        Ok(true)
     }
 
     /// This either creates a new session or returns the existing one

--- a/libsysinspect/src/cfg/mmconf.rs
+++ b/libsysinspect/src/cfg/mmconf.rs
@@ -844,10 +844,7 @@ impl MinionConfig {
     /// Path to the journal directory.
     /// Default: `{managed_db_dir}/journal`.
     pub fn journal_path(&self) -> PathBuf {
-        self.journal_path.as_ref().map_or_else(
-            || self.managed_db_dir().join(CFG_JOURNAL_DIR),
-            PathBuf::from,
-        )
+        self.journal_path.as_ref().map_or_else(|| self.managed_db_dir().join(CFG_JOURNAL_DIR), PathBuf::from)
     }
 
     pub fn set_journal_path(&mut self, path: &str) {

--- a/libsysinspect/src/cfg/mmconf.rs
+++ b/libsysinspect/src/cfg/mmconf.rs
@@ -139,10 +139,14 @@ pub static CFG_AUTOSYNC_FAST: &str = "fast";
 pub static CFG_AUTOSYNC_SHALLOW: &str = "shallow";
 pub static CFG_AUTOSYNC_DEFAULT: &str = CFG_AUTOSYNC_FULL;
 
-// Reconnect to the master
+// Reconect to the master
 pub static CFG_RECONNECT_DEFAULT: bool = true;
 pub static CFG_RECONNECT_FREQ_DEFAULT: u32 = 0;
 pub static CFG_RECONNECT_DEFAULT_INTERVAL: &str = "5-30";
+
+// Outgoing journal
+pub static CFG_JOURNAL_MAX_BYTES_DEFAULT: u64 = 64 * 1024 * 1024; // 64 MiB
+pub static CFG_JOURNAL_DIR: &str = "journal";
 
 // Task Intervals
 // ---------------
@@ -474,6 +478,18 @@ pub struct MinionConfig {
     #[serde(rename = "master.reconnect.interval")]
     #[serde(skip_serializing_if = "Option::is_none")]
     master_reconnect_interval: Option<String>,
+
+    /// Maximum disk space for the outgoing journal (bytes).
+    /// Default: 64 MiB. Set to 0 to disable the budget (unlimited).
+    #[serde(rename = "journal.size", default, deserialize_with = "libcommon::humaninput::h2bytes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    journal_max_bytes: Option<u64>,
+
+    /// Path to the persistent journal directory.
+    /// Default: `{managed_db_dir}/journal`.
+    #[serde(rename = "journal.path")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    journal_path: Option<String>,
 
     // Standard log for daemon mode
     #[serde(rename = "log.stream")]
@@ -813,6 +829,29 @@ impl MinionConfig {
         }
 
         rand::random::<u64>() % 30 + 5
+    }
+
+    /// Maximum outgoing journal size in bytes.
+    /// 0 = unlimited, default = 64 MiB.
+    pub fn journal_max_bytes(&self) -> u64 {
+        self.journal_max_bytes.unwrap_or(CFG_JOURNAL_MAX_BYTES_DEFAULT)
+    }
+
+    pub fn set_journal_max_bytes(&mut self, max_bytes: u64) {
+        self.journal_max_bytes = Some(max_bytes);
+    }
+
+    /// Path to the journal directory.
+    /// Default: `{managed_db_dir}/journal`.
+    pub fn journal_path(&self) -> PathBuf {
+        self.journal_path.as_ref().map_or_else(
+            || self.managed_db_dir().join(CFG_JOURNAL_DIR),
+            PathBuf::from,
+        )
+    }
+
+    pub fn set_journal_path(&mut self, path: &str) {
+        self.journal_path = Some(path.to_string());
     }
 
     /// Get temp path

--- a/libsysinspect/src/cfg/mmconf_ut.rs
+++ b/libsysinspect/src/cfg/mmconf_ut.rs
@@ -221,3 +221,61 @@ fn minion_performance_can_be_set_to_embedded_or_server() {
     assert_eq!(server.performance().register_threads(), (4, 4));
     assert_eq!(server.performance().daemon_threads(), (8, 8));
 }
+
+#[test]
+fn minion_journal_uses_default_max_bytes() {
+    let cfg = MinionConfig::default();
+    assert_eq!(cfg.journal_max_bytes(), 64 * 1024 * 1024); // 64 MiB
+}
+
+#[test]
+fn minion_journal_max_bytes_zero_disables_budget() {
+    let mut cfg = MinionConfig::default();
+    cfg.set_journal_max_bytes(0);
+    assert_eq!(cfg.journal_max_bytes(), 0);
+}
+
+#[test]
+fn minion_journal_custom_max_bytes() {
+    let mut cfg = MinionConfig::default();
+    cfg.set_journal_max_bytes(1024 * 1024);
+    assert_eq!(cfg.journal_max_bytes(), 1024 * 1024);
+}
+
+#[test]
+fn minion_journal_path_defaults_to_managed_db_dir() {
+    let cfg = MinionConfig::default();
+    assert_eq!(cfg.journal_path(), cfg.managed_db_dir().join("journal"));
+}
+
+#[test]
+fn minion_journal_path_follows_custom_managed_db_dir() {
+    let mut cfg = MinionConfig::default();
+    cfg.set_root_dir("/srv/sysinspect");
+    assert_eq!(cfg.journal_path(), std::path::PathBuf::from("/srv/sysinspect/tmp/journal"));
+}
+
+#[test]
+fn minion_journal_path_can_be_overridden() {
+    let mut cfg = MinionConfig::default();
+    cfg.set_journal_path("/var/lib/sysinspect/journal");
+    assert_eq!(cfg.journal_path(), std::path::PathBuf::from("/var/lib/sysinspect/journal"));
+}
+
+#[test]
+fn minion_journal_size_parses_human_readable_with_unit_suffix() {
+    let cfg = MinionConfig::new(write_master_cfg(
+        "config:\n  minion:\n    master.ip: ''\n    journal.size: 1 MB\n",
+    ))
+    .unwrap();
+    assert_eq!(cfg.journal_max_bytes(), 1_000_000);
+}
+
+#[test]
+fn minion_journal_size_parses_plain_integer() {
+    let cfg = MinionConfig::new(write_master_cfg(
+        "config:\n  minion:\n    master.ip: ''\n    journal.size: 65536\n",
+    ))
+    .unwrap();
+    assert_eq!(cfg.journal_max_bytes(), 65536);
+}

--- a/libsysinspect/src/cfg/mmconf_ut.rs
+++ b/libsysinspect/src/cfg/mmconf_ut.rs
@@ -264,18 +264,12 @@ fn minion_journal_path_can_be_overridden() {
 
 #[test]
 fn minion_journal_size_parses_human_readable_with_unit_suffix() {
-    let cfg = MinionConfig::new(write_master_cfg(
-        "config:\n  minion:\n    master.ip: ''\n    journal.size: 1 MB\n",
-    ))
-    .unwrap();
+    let cfg = MinionConfig::new(write_master_cfg("config:\n  minion:\n    master.ip: ''\n    journal.size: 1 MB\n")).unwrap();
     assert_eq!(cfg.journal_max_bytes(), 1_000_000);
 }
 
 #[test]
 fn minion_journal_size_parses_plain_integer() {
-    let cfg = MinionConfig::new(write_master_cfg(
-        "config:\n  minion:\n    master.ip: ''\n    journal.size: 65536\n",
-    ))
-    .unwrap();
+    let cfg = MinionConfig::new(write_master_cfg("config:\n  minion:\n    master.ip: ''\n    journal.size: 65536\n")).unwrap();
     assert_eq!(cfg.journal_max_bytes(), 65536);
 }

--- a/libsysinspect/src/journal.rs
+++ b/libsysinspect/src/journal.rs
@@ -22,7 +22,8 @@ pub struct Journal {
 
 impl Journal {
     pub fn open<P: AsRef<Path>>(path: P, max_bytes: u64) -> Result<Self, SysinspectError> {
-        let db = Arc::new(sled::open(path)?);
+        let config = sled::Config::new().flush_every_ms(Some(0)).path(&path);
+        let db = Arc::new(config.open()?);
         Ok(Self { pending: db.open_tree("pending")?, seq: db.open_tree("seq")?, acked: db.open_tree("acked")?, db, max_bytes })
     }
 
@@ -98,23 +99,30 @@ impl Journal {
         None
     }
 
-    fn ack_cycle_inner(&self, cycle_id: &str) {
+    fn ack_cycle_inner(&self, cycle_id: &str) -> usize {
         let prefix = Self::cycle_prefix(cycle_id);
         let keys: Vec<sled::IVec> = self.pending.scan_prefix(&prefix).filter_map(|r| r.ok().map(|(k, _)| k)).collect();
+        let mut count = 0usize;
         for k in &keys {
             if let Ok(Some(v)) = self.pending.get(k) {
-                self.add_total(-(v.len() as i64)).ok();
+                let _ = self.add_total(-(v.len() as i64));
             }
-            self.pending.remove(k).ok();
+            if self.pending.remove(k).is_ok() {
+                count += 1;
+            }
         }
-        self.acked.insert(cycle_id.as_bytes(), &[][..]).ok();
-        self.db.flush().ok();
+        let _ = self.acked.insert(cycle_id.as_bytes(), &[][..]);
+        let _ = self.db.flush();
+        count
     }
 
     // ---- public API ----
 
     /// Append a payload under a cycle.  Returns the per-cycle sequence number.
     pub fn append(&self, cycle_id: &str, payload: &[u8]) -> Result<u64, SysinspectError> {
+        if self.acked.contains_key(cycle_id.as_bytes())? {
+            self.acked.remove(cycle_id.as_bytes())?;
+        }
         let seq = self.next_seq(cycle_id)?;
         self.pending.insert(Self::pending_key(cycle_id, seq), payload)?;
         self.add_total(payload.len() as i64)?;
@@ -127,12 +135,12 @@ impl Journal {
 
     /// Acknowledge a cycle — all its entries are deleted.
     /// Idempotent: calling twice on the same cycle is safe.
-    pub fn ack_cycle(&self, cycle_id: &str) -> Result<(), SysinspectError> {
+    /// Returns the number of entries freed.
+    pub fn ack_cycle(&self, cycle_id: &str) -> Result<usize, SysinspectError> {
         if self.acked.contains_key(cycle_id.as_bytes())? {
-            return Ok(());
+            return Ok(0);
         }
-        self.ack_cycle_inner(cycle_id);
-        Ok(())
+        Ok(self.ack_cycle_inner(cycle_id))
     }
 
     /// Return all un-acked cycles with their entries in insertion order.

--- a/libsysinspect/src/journal.rs
+++ b/libsysinspect/src/journal.rs
@@ -14,9 +14,10 @@ pub type CycleEntries = Vec<(String, Vec<CycleEntry>)>;
 #[derive(Clone, Debug)]
 pub struct Journal {
     db: Arc<Db>,
-    pending: Tree, // key = cycle_id:seq, val = payload
-    seq: Tree,     // key = cycle_id, val = next_seq (u64 BE)
-    acked: Tree,   // key = cycle_id, val = "" (marker, entries already deleted)
+    pending: Tree,   // key = cycle_id:seq, val = payload
+    seq: Tree,       // key = cycle_id, val = next_seq (u64 BE)
+    acked: Tree,     // key = cycle_id, val = "" (marker, entries already deleted)
+    completed: Tree, // key = cycle_id, val = "" (local execution finished, delivery may still be pending)
     max_bytes: u64,
 }
 
@@ -24,7 +25,14 @@ impl Journal {
     pub fn open<P: AsRef<Path>>(path: P, max_bytes: u64) -> Result<Self, SysinspectError> {
         let config = sled::Config::new().flush_every_ms(Some(0)).path(&path);
         let db = Arc::new(config.open()?);
-        Ok(Self { pending: db.open_tree("pending")?, seq: db.open_tree("seq")?, acked: db.open_tree("acked")?, db, max_bytes })
+        Ok(Self {
+            pending: db.open_tree("pending")?,
+            seq: db.open_tree("seq")?,
+            acked: db.open_tree("acked")?,
+            completed: db.open_tree("completed")?,
+            db,
+            max_bytes,
+        })
     }
 
     // ---- helpers ----
@@ -112,6 +120,7 @@ impl Journal {
             }
         }
         let _ = self.acked.insert(cycle_id.as_bytes(), &[][..]);
+        let _ = self.completed.remove(cycle_id.as_bytes());
         let _ = self.db.flush();
         count
     }
@@ -141,6 +150,18 @@ impl Journal {
             return Ok(0);
         }
         Ok(self.ack_cycle_inner(cycle_id))
+    }
+
+    /// Mark a cycle as locally completed. Delivery may still be pending until master `CycleAck` arrives.
+    pub fn mark_cycle_locally_complete(&self, cycle_id: &str) -> Result<(), SysinspectError> {
+        self.completed.insert(cycle_id.as_bytes(), &[][..])?;
+        self.db.flush()?;
+        Ok(())
+    }
+
+    /// Return whether the cycle has already finished local execution and only delivery recovery may remain.
+    pub fn is_cycle_locally_complete(&self, cycle_id: &str) -> Result<bool, SysinspectError> {
+        self.completed.contains_key(cycle_id.as_bytes()).map_err(Into::into)
     }
 
     /// Return all un-acked cycles with their entries in insertion order.

--- a/libsysinspect/src/journal.rs
+++ b/libsysinspect/src/journal.rs
@@ -1,0 +1,176 @@
+//! Cycle-keyed persistent journal with ACK-based eviction.
+//!
+//! Payloads are grouped by `cycle_id`.  When the consumer acknowledges a
+//! cycle all its entries are freed.  A byte budget caps un-acked data;
+//! the oldest cycle is evicted when the budget is exceeded.
+
+use libcommon::SysinspectError;
+use sled::{Db, Tree};
+use std::{path::Path, sync::Arc};
+
+#[derive(Clone, Debug)]
+pub struct Journal {
+    db: Arc<Db>,
+    pending: Tree,   // key = cycle_id:seq, val = payload
+    seq: Tree,       // key = cycle_id, val = next_seq (u64 BE)
+    acked: Tree,     // key = cycle_id, val = "" (marker, entries already deleted)
+    max_bytes: u64,
+}
+
+impl Journal {
+    pub fn open<P: AsRef<Path>>(path: P, max_bytes: u64) -> Result<Self, SysinspectError> {
+        let db = Arc::new(sled::open(path)?);
+        Ok(Self {
+            pending: db.open_tree("pending")?,
+            seq: db.open_tree("seq")?,
+            acked: db.open_tree("acked")?,
+            db,
+            max_bytes,
+        })
+    }
+
+    // ---- helpers ----
+
+    fn pending_key(cycle_id: &str, seq: u64) -> Vec<u8> {
+        let mut k = Vec::with_capacity(cycle_id.len() + 1 + 8);
+        k.extend_from_slice(cycle_id.as_bytes());
+        k.push(b':');
+        k.extend_from_slice(&seq.to_be_bytes());
+        k
+    }
+
+    fn cycle_prefix(cycle_id: &str) -> Vec<u8> {
+        let mut k = Vec::with_capacity(cycle_id.len() + 1);
+        k.extend_from_slice(cycle_id.as_bytes());
+        k.push(b':');
+        k
+    }
+
+    fn next_seq(&self, cycle_id: &str) -> Result<u64, SysinspectError> {
+        let raw = self.seq.fetch_and_update(cycle_id.as_bytes(), |old| {
+            let cur = old.and_then(|v| {
+                if v.len() >= 8 { Some(u64::from_be_bytes(v[..8].try_into().unwrap())) } else { None }
+            }).unwrap_or(0);
+            Some(cur.wrapping_add(1).to_be_bytes().to_vec())
+        })?;
+        let assigned = raw.and_then(|v| {
+            if v.len() >= 8 { Some(u64::from_be_bytes(v[..8].try_into().unwrap())) } else { None }
+        }).unwrap_or(0);
+        Ok(assigned)
+    }
+
+    fn total_key() -> &'static [u8] {
+        b"__total_bytes"
+    }
+
+    fn add_total(&self, delta: i64) -> Result<u64, SysinspectError> {
+        let raw = self.pending.fetch_and_update(Self::total_key(), |old| {
+            let cur = old.and_then(|v| {
+                if v.len() >= 8 { Some(i64::from_be_bytes(v[..8].try_into().unwrap())) } else { None }
+            }).unwrap_or(0);
+            Some((cur + delta).max(0).to_be_bytes().to_vec())
+        })?;
+        Ok(raw.and_then(|v| {
+            if v.len() >= 8 { Some(i64::from_be_bytes(v[..8].try_into().unwrap()) as u64) } else { None }
+        }).unwrap_or(0))
+    }
+
+    fn _total_bytes(&self) -> u64 {
+        self.pending.get(Self::total_key()).ok().flatten().and_then(|v| {
+            if v.len() >= 8 { Some(i64::from_be_bytes(v[..8].try_into().unwrap()) as u64) } else { None }
+        }).unwrap_or(0)
+    }
+
+    fn evict_if_needed(&self) {
+        if self.max_bytes == 0 {
+            return;
+        }
+        while self._total_bytes() > self.max_bytes {
+            let Some(oldest) = self.oldest_unacked_cycle() else {
+                break;
+            };
+            self.ack_cycle_inner(&oldest);
+        }
+    }
+
+    fn oldest_unacked_cycle(&self) -> Option<String> {
+        for item in self.pending.iter() {
+            let (k, _) = item.ok()?;
+            let key_bytes = k.as_ref();
+            if key_bytes.starts_with(b"__") {
+                continue;
+            }
+            let colon = key_bytes.iter().rposition(|&b| b == b':')?;
+            return Some(String::from_utf8_lossy(&key_bytes[..colon]).to_string());
+        }
+        None
+    }
+
+    fn ack_cycle_inner(&self, cycle_id: &str) {
+        let prefix = Self::cycle_prefix(cycle_id);
+        let keys: Vec<sled::IVec> = self.pending.scan_prefix(&prefix).filter_map(|r| r.ok().map(|(k, _)| k)).collect();
+        for k in &keys {
+            if let Ok(Some(v)) = self.pending.get(k) {
+                self.add_total(-(v.len() as i64)).ok();
+            }
+            self.pending.remove(k).ok();
+        }
+        self.acked.insert(cycle_id.as_bytes(), &[][..]).ok();
+        self.db.flush().ok();
+    }
+
+    // ---- public API ----
+
+    /// Append a payload under a cycle.  Returns the per-cycle sequence number.
+    pub fn append(&self, cycle_id: &str, payload: &[u8]) -> Result<u64, SysinspectError> {
+        let seq = self.next_seq(cycle_id)?;
+        self.pending.insert(Self::pending_key(cycle_id, seq), payload)?;
+        self.add_total(payload.len() as i64)?;
+        self.db.flush()?;
+        if self.max_bytes > 0 {
+            self.evict_if_needed();
+        }
+        Ok(seq)
+    }
+
+    /// Acknowledge a cycle — all its entries are deleted.
+    /// Idempotent: calling twice on the same cycle is safe.
+    pub fn ack_cycle(&self, cycle_id: &str) -> Result<(), SysinspectError> {
+        if self.acked.contains_key(cycle_id.as_bytes())? {
+            return Ok(());
+        }
+        self.ack_cycle_inner(cycle_id);
+        Ok(())
+    }
+
+    /// Return all un-acked cycles with their entries in insertion order.
+    pub fn pending(&self) -> Result<Vec<(String, Vec<(u64, Vec<u8>)>)>, SysinspectError> {
+        let mut cycles: Vec<(String, Vec<(u64, Vec<u8>)>)> = Vec::new();
+        for item in self.pending.iter() {
+            let (k, v) = item?;
+            let key_bytes = k.as_ref();
+            if key_bytes.starts_with(b"__") {
+                continue;
+            }
+            let colon = match key_bytes.iter().rposition(|&b| b == b':') {
+                Some(pos) => pos,
+                None => continue,
+            };
+            let cycle_id = String::from_utf8_lossy(&key_bytes[..colon]).to_string();
+            let seq = if key_bytes.len() >= colon + 9 {
+                u64::from_be_bytes(key_bytes[colon + 1..colon + 9].try_into().unwrap())
+            } else {
+                continue;
+            };
+            if let Some(last) = cycles.last_mut()
+                && last.0 == cycle_id
+            {
+                last.1.push((seq, v.to_vec()));
+            } else {
+                cycles.push((cycle_id, vec![(seq, v.to_vec())]));
+            }
+        }
+        Ok(cycles)
+    }
+}
+

--- a/libsysinspect/src/journal.rs
+++ b/libsysinspect/src/journal.rs
@@ -8,25 +8,22 @@ use libcommon::SysinspectError;
 use sled::{Db, Tree};
 use std::{path::Path, sync::Arc};
 
+pub type CycleEntry = (u64, Vec<u8>);
+pub type CycleEntries = Vec<(String, Vec<CycleEntry>)>;
+
 #[derive(Clone, Debug)]
 pub struct Journal {
     db: Arc<Db>,
-    pending: Tree,   // key = cycle_id:seq, val = payload
-    seq: Tree,       // key = cycle_id, val = next_seq (u64 BE)
-    acked: Tree,     // key = cycle_id, val = "" (marker, entries already deleted)
+    pending: Tree, // key = cycle_id:seq, val = payload
+    seq: Tree,     // key = cycle_id, val = next_seq (u64 BE)
+    acked: Tree,   // key = cycle_id, val = "" (marker, entries already deleted)
     max_bytes: u64,
 }
 
 impl Journal {
     pub fn open<P: AsRef<Path>>(path: P, max_bytes: u64) -> Result<Self, SysinspectError> {
         let db = Arc::new(sled::open(path)?);
-        Ok(Self {
-            pending: db.open_tree("pending")?,
-            seq: db.open_tree("seq")?,
-            acked: db.open_tree("acked")?,
-            db,
-            max_bytes,
-        })
+        Ok(Self { pending: db.open_tree("pending")?, seq: db.open_tree("seq")?, acked: db.open_tree("acked")?, db, max_bytes })
     }
 
     // ---- helpers ----
@@ -48,14 +45,10 @@ impl Journal {
 
     fn next_seq(&self, cycle_id: &str) -> Result<u64, SysinspectError> {
         let raw = self.seq.fetch_and_update(cycle_id.as_bytes(), |old| {
-            let cur = old.and_then(|v| {
-                if v.len() >= 8 { Some(u64::from_be_bytes(v[..8].try_into().unwrap())) } else { None }
-            }).unwrap_or(0);
+            let cur = old.and_then(|v| if v.len() >= 8 { Some(u64::from_be_bytes(v[..8].try_into().unwrap())) } else { None }).unwrap_or(0);
             Some(cur.wrapping_add(1).to_be_bytes().to_vec())
         })?;
-        let assigned = raw.and_then(|v| {
-            if v.len() >= 8 { Some(u64::from_be_bytes(v[..8].try_into().unwrap())) } else { None }
-        }).unwrap_or(0);
+        let assigned = raw.and_then(|v| if v.len() >= 8 { Some(u64::from_be_bytes(v[..8].try_into().unwrap())) } else { None }).unwrap_or(0);
         Ok(assigned)
     }
 
@@ -65,20 +58,19 @@ impl Journal {
 
     fn add_total(&self, delta: i64) -> Result<u64, SysinspectError> {
         let raw = self.pending.fetch_and_update(Self::total_key(), |old| {
-            let cur = old.and_then(|v| {
-                if v.len() >= 8 { Some(i64::from_be_bytes(v[..8].try_into().unwrap())) } else { None }
-            }).unwrap_or(0);
+            let cur = old.and_then(|v| if v.len() >= 8 { Some(i64::from_be_bytes(v[..8].try_into().unwrap())) } else { None }).unwrap_or(0);
             Some((cur + delta).max(0).to_be_bytes().to_vec())
         })?;
-        Ok(raw.and_then(|v| {
-            if v.len() >= 8 { Some(i64::from_be_bytes(v[..8].try_into().unwrap()) as u64) } else { None }
-        }).unwrap_or(0))
+        Ok(raw.and_then(|v| if v.len() >= 8 { Some(i64::from_be_bytes(v[..8].try_into().unwrap()) as u64) } else { None }).unwrap_or(0))
     }
 
     fn _total_bytes(&self) -> u64 {
-        self.pending.get(Self::total_key()).ok().flatten().and_then(|v| {
-            if v.len() >= 8 { Some(i64::from_be_bytes(v[..8].try_into().unwrap()) as u64) } else { None }
-        }).unwrap_or(0)
+        self.pending
+            .get(Self::total_key())
+            .ok()
+            .flatten()
+            .and_then(|v| if v.len() >= 8 { Some(i64::from_be_bytes(v[..8].try_into().unwrap()) as u64) } else { None })
+            .unwrap_or(0)
     }
 
     fn evict_if_needed(&self) {
@@ -144,8 +136,8 @@ impl Journal {
     }
 
     /// Return all un-acked cycles with their entries in insertion order.
-    pub fn pending(&self) -> Result<Vec<(String, Vec<(u64, Vec<u8>)>)>, SysinspectError> {
-        let mut cycles: Vec<(String, Vec<(u64, Vec<u8>)>)> = Vec::new();
+    pub fn pending(&self) -> Result<CycleEntries, SysinspectError> {
+        let mut cycles: CycleEntries = Vec::new();
         for item in self.pending.iter() {
             let (k, v) = item?;
             let key_bytes = k.as_ref();
@@ -173,4 +165,3 @@ impl Journal {
         Ok(cycles)
     }
 }
-

--- a/libsysinspect/src/journal.rs
+++ b/libsysinspect/src/journal.rs
@@ -21,9 +21,12 @@ pub struct JournalStats {
 #[derive(Clone, Debug)]
 pub struct Journal {
     db: Arc<Db>,
-    pending: Tree,   // key = cycle_id:seq, val = payload
-    seq: Tree,       // key = cycle_id, val = next_seq (u64 BE)
-    acked: Tree,     // key = cycle_id, val = "" (marker, entries already deleted)
+    pending: Tree, // key = cycle_id:seq, val = payload
+    seq: Tree,     // key = cycle_id, val = next_seq (u64 BE)
+    acked: Tree,   // key = cycle_id, val = "" (marker, entries already deleted)
+    // Local execution and network delivery are separated on purpose. Once a cycle is
+    // marked completed here, hard-restart recovery must not re-run it; only journal replay
+    // is allowed to finish delivery until master `CycleAck` clears the cycle.
     completed: Tree, // key = cycle_id, val = "" (local execution finished, delivery may still be pending)
     max_bytes: u64,
 }

--- a/libsysinspect/src/journal.rs
+++ b/libsysinspect/src/journal.rs
@@ -11,6 +11,13 @@ use std::{path::Path, sync::Arc};
 pub type CycleEntry = (u64, Vec<u8>);
 pub type CycleEntries = Vec<(String, Vec<CycleEntry>)>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct JournalStats {
+    pub pending_cycles: usize,
+    pub pending_entries: usize,
+    pub pending_bytes: u64,
+}
+
 #[derive(Clone, Debug)]
 pub struct Journal {
     db: Arc<Db>,
@@ -90,6 +97,7 @@ impl Journal {
             let Some(oldest) = self.oldest_unacked_cycle() else {
                 break;
             };
+            log::warn!("Journal exceeded byte budget ({} > {}); evicting oldest unacked cycle {}", self._total_bytes(), self.max_bytes, oldest);
             self.ack_cycle_inner(&oldest);
         }
     }
@@ -162,6 +170,29 @@ impl Journal {
     /// Return whether the cycle has already finished local execution and only delivery recovery may remain.
     pub fn is_cycle_locally_complete(&self, cycle_id: &str) -> Result<bool, SysinspectError> {
         self.completed.contains_key(cycle_id.as_bytes()).map_err(Into::into)
+    }
+
+    /// Return current backlog counters for operator visibility.
+    pub fn stats(&self) -> Result<JournalStats, SysinspectError> {
+        let mut stats = JournalStats { pending_bytes: self._total_bytes(), ..Default::default() };
+        let mut last_cycle: Option<String> = None;
+        for item in self.pending.iter() {
+            let (k, _v) = item?;
+            let key_bytes = k.as_ref();
+            if key_bytes.starts_with(b"__") {
+                continue;
+            }
+            let Some(colon) = key_bytes.iter().rposition(|&b| b == b':') else {
+                continue;
+            };
+            let cycle_id = String::from_utf8_lossy(&key_bytes[..colon]).to_string();
+            stats.pending_entries += 1;
+            if last_cycle.as_deref() != Some(cycle_id.as_str()) {
+                stats.pending_cycles += 1;
+                last_cycle = Some(cycle_id);
+            }
+        }
+        Ok(stats)
     }
 
     /// Return all un-acked cycles with their entries in insertion order.

--- a/libsysinspect/src/journal_ut.rs
+++ b/libsysinspect/src/journal_ut.rs
@@ -319,7 +319,7 @@ fn large_payload_near_budget_single_entry_causes_eviction() {
     let dir = temp_dir();
     let j = Journal::open(&dir, 50).unwrap();
     j.append("alpha", b"1234567890").unwrap();
-    j.append("beta",  b"1234567890").unwrap();
+    j.append("beta", b"1234567890").unwrap();
     j.append("gamma", b"1234567890").unwrap();
     j.append("extra", &vec![0u8; 45]).unwrap();
     let pending = j.pending().unwrap();

--- a/libsysinspect/src/journal_ut.rs
+++ b/libsysinspect/src/journal_ut.rs
@@ -220,6 +220,24 @@ fn append_after_ack_reuses_cycle_id() {
 }
 
 #[test]
+fn completed_cycle_marker_persists_across_reopen_until_ack() {
+    let dir = temp_dir();
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        j.append("c1", b"payload").unwrap();
+        j.mark_cycle_locally_complete("c1").unwrap();
+        assert!(j.is_cycle_locally_complete("c1").unwrap());
+    }
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        assert!(j.is_cycle_locally_complete("c1").unwrap());
+        j.ack_cycle("c1").unwrap();
+        assert!(!j.is_cycle_locally_complete("c1").unwrap());
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn cycle_id_with_colons() {
     let dir = temp_dir();
     let j = Journal::open(&dir, 0).unwrap();

--- a/libsysinspect/src/journal_ut.rs
+++ b/libsysinspect/src/journal_ut.rs
@@ -238,6 +238,22 @@ fn completed_cycle_marker_persists_across_reopen_until_ack() {
 }
 
 #[test]
+fn stats_report_cycles_entries_and_bytes() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    j.append("c1", b"aa").unwrap();
+    j.append("c1", b"bbb").unwrap();
+    j.append("c2", b"cccc").unwrap();
+
+    let stats = j.stats().unwrap();
+    assert_eq!(stats.pending_cycles, 2);
+    assert_eq!(stats.pending_entries, 3);
+    assert_eq!(stats.pending_bytes, 9);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn cycle_id_with_colons() {
     let dir = temp_dir();
     let j = Journal::open(&dir, 0).unwrap();

--- a/libsysinspect/src/journal_ut.rs
+++ b/libsysinspect/src/journal_ut.rs
@@ -1,0 +1,351 @@
+use crate::journal::Journal;
+
+fn temp_dir() -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "libsysinspect-journal-ut-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn append_returns_per_cycle_sequence() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    assert_eq!(j.append("c1", b"a").unwrap(), 0);
+    assert_eq!(j.append("c1", b"b").unwrap(), 1);
+    assert_eq!(j.append("c2", b"x").unwrap(), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ack_cycle_deletes_entries() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    j.append("c1", b"hello").unwrap();
+    j.append("c1", b"world").unwrap();
+    j.append("c2", b"keep").unwrap();
+    j.ack_cycle("c1").unwrap();
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].0, "c2");
+    assert_eq!(pending[0].1[0].1, b"keep");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ack_is_idempotent() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    j.append("c1", b"x").unwrap();
+    j.ack_cycle("c1").unwrap();
+    j.ack_cycle("c1").unwrap();
+    assert!(j.pending().unwrap().is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pending_empty_on_fresh_journal() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    assert!(j.pending().unwrap().is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn evicts_oldest_cycle_when_over_budget() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 20).unwrap();
+    j.append("c1", b"1234567890").unwrap();
+    j.append("c1", b"abcdefghij").unwrap();
+    j.append("c2", b"overflow!").unwrap();
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].0, "c2");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn state_persists_across_reopen() {
+    let dir = temp_dir();
+    let j1 = Journal::open(&dir, 0).unwrap();
+    j1.append("c1", b"lost").unwrap();
+    drop(j1);
+    let j2 = Journal::open(&dir, 0).unwrap();
+    let pending = j2.pending().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].0, "c1");
+    assert_eq!(pending[0].1[0].1, b"lost");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn multi_cycle_ack_partial() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    j.append("c1", b"a").unwrap();
+    j.append("c1", b"b").unwrap();
+    j.append("c2", b"x").unwrap();
+    j.append("c3", b"1").unwrap();
+    j.append("c3", b"2").unwrap();
+    j.ack_cycle("c2").unwrap();
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), 2);
+    assert_eq!(pending[0].0, "c1");
+    assert_eq!(pending[1].0, "c3");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ack_before_append_is_noop() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    j.ack_cycle("never_written").unwrap();
+    assert!(j.pending().unwrap().is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pending_preserves_insertion_order() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    j.append("c1", b"first").unwrap();
+    j.append("c2", b"second").unwrap();
+    j.append("c1", b"third").unwrap();
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), 2);
+    assert_eq!(pending[0].0, "c1");
+    assert_eq!(pending[0].1.len(), 2);
+    assert_eq!(pending[1].0, "c2");
+    assert_eq!(pending[1].1.len(), 1);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn reopen_after_partial_ack_preserves_survivors() {
+    let dir = temp_dir();
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        j.append("c1", b"keep").unwrap();
+        j.append("c2", b"drop").unwrap();
+        j.ack_cycle("c2").unwrap();
+    }
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        let pending = j.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0, "c1");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn budget_applies_after_reopen() {
+    let dir = temp_dir();
+    {
+        let j = Journal::open(&dir, 20).unwrap();
+        j.append("c1", b"1234567890").unwrap();
+    }
+    {
+        let j = Journal::open(&dir, 20).unwrap();
+        j.append("c1", b"abcdefghij").unwrap();
+        j.append("c2", b"overflow!").unwrap();
+        let pending = j.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0, "c2");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ---- edge cases ----
+
+#[test]
+fn empty_cycle_id_is_valid() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    let s = j.append("", b"data").unwrap();
+    assert_eq!(s, 0);
+    let pending = j.pending().unwrap();
+    assert_eq!(pending[0].0, "");
+    assert_eq!(pending[0].1[0].1, b"data");
+    j.ack_cycle("").unwrap();
+    assert!(j.pending().unwrap().is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn empty_payload_is_valid() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    j.append("c", b"").unwrap();
+    let pending = j.pending().unwrap();
+    assert_eq!(pending[0].1[0].1.len(), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn payload_exactly_at_budget_does_not_evict() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 10).unwrap();
+    j.append("c1", b"1234567890").unwrap();
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), 1);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn eviction_wipes_only_cycle_when_budget_exceeded() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 5).unwrap();
+    j.append("only", b"1234567890").unwrap();
+    assert!(j.pending().unwrap().is_empty(), "single cycle over budget should be evicted");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn append_after_ack_reuses_cycle_id() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    j.append("c1", b"first").unwrap();
+    j.ack_cycle("c1").unwrap();
+    let s = j.append("c1", b"second").unwrap();
+    assert_eq!(s, 1);
+    let pending = j.pending().unwrap();
+    assert_eq!(pending[0].1[0].1, b"second");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn cycle_id_with_colons() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    j.append("a:b:c", b"x").unwrap();
+    j.append("a:b:c", b"y").unwrap();
+    let pending = j.pending().unwrap();
+    assert_eq!(pending[0].0, "a:b:c");
+    assert_eq!(pending[0].1.len(), 2);
+    j.ack_cycle("a:b:c").unwrap();
+    assert!(j.pending().unwrap().is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn very_long_cycle_id() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    let long = "x".repeat(1024);
+    j.append(&long, b"data").unwrap();
+    let pending = j.pending().unwrap();
+    assert_eq!(pending[0].1[0].1, b"data");
+    j.ack_cycle(&long).unwrap();
+    assert!(j.pending().unwrap().is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn multi_entry_cycle_ordering_within_cycle() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    for i in 0..50u8 {
+        j.append("c", &[i]).unwrap();
+    }
+    let pending = j.pending().unwrap();
+    assert_eq!(pending[0].1.len(), 50);
+    for (i, (seq, payload)) in pending[0].1.iter().enumerate() {
+        assert_eq!(*seq, i as u64);
+        assert_eq!(payload, &[i as u8]);
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ---- stress / integration tests ----
+
+#[test]
+fn many_cycles_with_many_entries() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    for ci in 0..200u16 {
+        let cid = format!("cycle-{:04}", ci);
+        for ei in 0..5 {
+            j.append(&cid, format!("entry-{}", ei).as_bytes()).unwrap();
+        }
+    }
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), 200);
+    assert_eq!(pending[0].0, "cycle-0000");
+    assert_eq!(pending[199].0, "cycle-0199");
+    for (_, entries) in &pending {
+        assert_eq!(entries.len(), 5);
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn interleaved_append_and_ack() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 0).unwrap();
+    for i in 0..100u16 {
+        let cid = format!("c-{}", i);
+        j.append(&cid, b"data").unwrap();
+        j.append(&cid, b"more").unwrap();
+        if i % 2 == 0 && i > 0 {
+            let prev = format!("c-{}", i - 1);
+            j.ack_cycle(&prev).unwrap();
+        }
+    }
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), 51);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn budget_pressure_many_tiny_cycles() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 200).unwrap();
+    for i in 0..50u16 {
+        let cid = format!("cycle-{:04}", i);
+        j.append(&cid, b"0123456789").unwrap();
+    }
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), 20);
+    assert_eq!(pending[0].0, "cycle-0030");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn large_payload_near_budget_single_entry_causes_eviction() {
+    let dir = temp_dir();
+    let j = Journal::open(&dir, 50).unwrap();
+    j.append("alpha", b"1234567890").unwrap();
+    j.append("beta",  b"1234567890").unwrap();
+    j.append("gamma", b"1234567890").unwrap();
+    j.append("extra", &vec![0u8; 45]).unwrap();
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].0, "gamma");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn reopen_and_continue_appending() {
+    let dir = temp_dir();
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        j.append("c1", b"a").unwrap();
+        j.append("c2", b"b").unwrap();
+        j.ack_cycle("c1").unwrap();
+    }
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        j.append("c2", b"c").unwrap();
+        j.append("c3", b"d").unwrap();
+        let pending = j.pending().unwrap();
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].0, "c2");
+        assert_eq!(pending[0].1.len(), 2);
+        assert_eq!(pending[1].0, "c3");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/libsysinspect/src/journal_ut.rs
+++ b/libsysinspect/src/journal_ut.rs
@@ -214,6 +214,8 @@ fn append_after_ack_reuses_cycle_id() {
     assert_eq!(s, 1);
     let pending = j.pending().unwrap();
     assert_eq!(pending[0].1[0].1, b"second");
+    assert_eq!(j.ack_cycle("c1").unwrap(), 1);
+    assert!(j.pending().unwrap().is_empty());
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/libsysinspect/src/lib.rs
+++ b/libsysinspect/src/lib.rs
@@ -3,6 +3,7 @@ pub mod console;
 pub mod context;
 pub mod inspector;
 pub mod intp;
+pub mod journal;
 pub mod logger;
 pub mod mdescr;
 pub mod reactor;
@@ -11,3 +12,6 @@ pub mod tmpl;
 pub mod traits;
 pub mod transport;
 pub mod util;
+
+#[cfg(test)]
+mod journal_ut;

--- a/libsysinspect/tests/journal_integration.rs
+++ b/libsysinspect/tests/journal_integration.rs
@@ -6,10 +6,7 @@ fn temp_dir(label: &str) -> std::path::PathBuf {
     let dir = std::env::temp_dir().join(format!(
         "libsysinspect-journal-int-{}-{}-{}",
         std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos(),
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos(),
         label
     ));
     std::fs::create_dir_all(&dir).unwrap();
@@ -105,11 +102,7 @@ fn heavy_budget_pressure() {
     let survivor_ids: Vec<&str> = pending.iter().map(|(c, _)| c.as_str()).collect();
     for i in (170..200u16).rev() {
         let expected = format!("c-{:04}", i);
-        assert!(
-            survivor_ids.contains(&expected.as_str()),
-            "newest cycle {} should survive budget pressure",
-            expected
-        );
+        assert!(survivor_ids.contains(&expected.as_str()), "newest cycle {} should survive budget pressure", expected);
     }
 
     drop(pending);

--- a/libsysinspect/tests/journal_integration.rs
+++ b/libsysinspect/tests/journal_integration.rs
@@ -1,0 +1,281 @@
+use libsysinspect::journal::Journal;
+use std::sync::Arc;
+use std::thread;
+
+fn temp_dir(label: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "libsysinspect-journal-int-{}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        label
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn concurrent_appends_across_threads() {
+    let dir = temp_dir("concurrent");
+    let j = Arc::new(Journal::open(&dir, 0).unwrap());
+    let cycles: usize = 50;
+    let threads: usize = 4;
+
+    let handles: Vec<_> = (0..threads)
+        .map(|t| {
+            let j = Arc::clone(&j);
+            thread::spawn(move || {
+                for c in 0..cycles {
+                    let cid = format!("t{}-c{}", t, c);
+                    for e in 0..10 {
+                        j.append(&cid, format!("entry-{}", e).as_bytes()).unwrap();
+                    }
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let pending = j.pending().unwrap();
+    assert_eq!(pending.len(), threads * cycles);
+    for (_, entries) in &pending {
+        assert_eq!(entries.len(), 10);
+    }
+
+    drop(pending);
+    drop(j);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn crash_recovery_after_append() {
+    let dir = temp_dir("crash");
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        for i in 0..50u16 {
+            j.append(&format!("c-{:04}", i), b"data").unwrap();
+        }
+        // Simulate crash: drop without ack
+    }
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        let pending = j.pending().unwrap();
+        assert_eq!(pending.len(), 50);
+        assert_eq!(pending[0].0, "c-0000");
+        assert_eq!(pending[49].0, "c-0049");
+
+        // Ack first 25
+        for i in 0..25u16 {
+            j.ack_cycle(&format!("c-{:04}", i)).unwrap();
+        }
+        let pending = j.pending().unwrap();
+        assert_eq!(pending.len(), 25);
+        assert_eq!(pending[0].0, "c-0025");
+    }
+    {
+        // Reopen: only 25 remain
+        let j = Journal::open(&dir, 0).unwrap();
+        let pending = j.pending().unwrap();
+        assert_eq!(pending.len(), 25);
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn heavy_budget_pressure() {
+    let dir = temp_dir("pressure");
+    let j = Journal::open(&dir, 500).unwrap();
+
+    // 200 cycles × 10 bytes = 2000 bytes. Budget 500.
+    // Should keep ~50 newest cycles.
+    for i in 0..200u16 {
+        j.append(&format!("c-{:04}", i), b"0123456789").unwrap();
+    }
+
+    let pending = j.pending().unwrap();
+    assert!(pending.len() >= 40, "expected at least 40 survivors under budget pressure, got {}", pending.len());
+    assert!(pending.len() <= 60, "expected at most 60 survivors, got {}", pending.len());
+
+    // Verify newest cycles survived (last 50 should still be here)
+    let survivor_ids: Vec<&str> = pending.iter().map(|(c, _)| c.as_str()).collect();
+    for i in (170..200u16).rev() {
+        let expected = format!("c-{:04}", i);
+        assert!(
+            survivor_ids.contains(&expected.as_str()),
+            "newest cycle {} should survive budget pressure",
+            expected
+        );
+    }
+
+    drop(pending);
+    drop(j);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rapid_ack_storm() {
+    let dir = temp_dir("ackstorm");
+    let j = Journal::open(&dir, 0).unwrap();
+
+    // Append 500 cycles with 3 entries each
+    for i in 0..500u16 {
+        let cid = format!("c-{:04}", i);
+        j.append(&cid, b"a").unwrap();
+        j.append(&cid, b"b").unwrap();
+        j.append(&cid, b"c").unwrap();
+    }
+
+    assert_eq!(j.pending().unwrap().len(), 500);
+
+    // Ack all of them rapidly
+    for i in 0..500u16 {
+        j.ack_cycle(&format!("c-{:04}", i)).unwrap();
+    }
+
+    assert!(j.pending().unwrap().is_empty());
+    drop(j);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn mixed_read_write_under_load() {
+    let dir = temp_dir("mixed");
+    let j = Arc::new(Journal::open(&dir, 0).unwrap());
+
+    let writer = {
+        let j = Arc::clone(&j);
+        thread::spawn(move || {
+            for i in 0..200u16 {
+                j.append(&format!("w-{:04}", i), b"write").unwrap();
+            }
+        })
+    };
+
+    let acker = {
+        let j = Arc::clone(&j);
+        thread::spawn(move || {
+            for _ in 0..10 {
+                let pending = j.pending().unwrap();
+                if let Some((cid, _)) = pending.first() {
+                    let cid = cid.clone();
+                    drop(pending);
+                    j.ack_cycle(&cid).unwrap();
+                }
+            }
+        })
+    };
+
+    let reader = {
+        let j = Arc::clone(&j);
+        thread::spawn(move || {
+            for _ in 0..20 {
+                let _ = j.pending().unwrap();
+                thread::sleep(std::time::Duration::from_micros(100));
+            }
+        })
+    };
+
+    writer.join().unwrap();
+    acker.join().unwrap();
+    reader.join().unwrap();
+
+    let pending = j.pending().unwrap();
+    // Some acked, some remain. All should be writer's cycles.
+    for (cid, _) in &pending {
+        assert!(cid.starts_with("w-"));
+    }
+
+    drop(pending);
+    drop(j);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn reopen_preserves_all_state_across_multiple_sessions() {
+    let dir = temp_dir("reopen");
+    let inputs: Vec<(&str, &[u8])> = vec![
+        ("session1", b"first"),
+        ("session1", b"second"),
+        ("session2", b"alpha"),
+        ("session2", b"beta"),
+        ("session2", b"gamma"),
+        ("session3", b"only"),
+    ];
+
+    // Session 1: append session1 data + session2 data, ack session1
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        j.append("session1", b"first").unwrap();
+        j.append("session1", b"second").unwrap();
+        j.append("session2", b"alpha").unwrap();
+        j.ack_cycle("session1").unwrap();
+    }
+
+    // Session 2: append more to session2, add session3
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        j.append("session2", b"beta").unwrap();
+        j.append("session2", b"gamma").unwrap();
+        j.append("session3", b"only").unwrap();
+        // Don't ack anything
+    }
+
+    // Session 3: verify all remaining
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        let pending = j.pending().unwrap();
+        assert_eq!(pending.len(), 2, "expected session2 and session3");
+        assert_eq!(pending[0].0, "session2");
+        assert_eq!(pending[0].1.len(), 3);
+        assert_eq!(pending[1].0, "session3");
+        assert_eq!(pending[1].1.len(), 1);
+
+        // Ack session2, keep session3
+        j.ack_cycle("session2").unwrap();
+        let pending2 = j.pending().unwrap();
+        assert_eq!(pending2.len(), 1);
+        assert_eq!(pending2[0].0, "session3");
+    }
+
+    // Session 4: only session3 remains
+    {
+        let j = Journal::open(&dir, 0).unwrap();
+        let pending = j.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0, "session3");
+    }
+
+    drop(inputs);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn large_payloads_stress() {
+    let dir = temp_dir("large");
+    let j = Journal::open(&dir, 64 * 1024).unwrap(); // 64 KiB budget
+
+    // Append many medium payloads
+    for i in 0..100u16 {
+        let payload = vec![(i % 256) as u8; 512]; // 512 bytes each
+        j.append(&format!("c-{}", i), &payload).unwrap();
+    }
+    // 100 × 512 = 51200 bytes under 64 KiB budget — none evicted
+    assert_eq!(j.pending().unwrap().len(), 100);
+
+    // Now blow past the budget
+    let huge = vec![0u8; 32 * 1024]; // 32 KiB
+    j.append("huge", &huge).unwrap();
+    // 51200 + 32768 = 83968 > 65536. ~36 oldest cycles evicted to make room.
+    let pending = j.pending().unwrap();
+    assert!(pending.len() < 70, "expected fewer than 70 cycles, got {}", pending.len());
+    assert!(pending.iter().any(|(c, _)| c == "huge"), "huge cycle should survive");
+
+    drop(pending);
+    drop(j);
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/libsysproto/src/lib.rs
+++ b/libsysproto/src/lib.rs
@@ -1,8 +1,12 @@
 pub mod errcodes;
 pub mod payload;
 pub mod query;
+pub mod replay;
 pub mod rqtypes;
 pub mod secure;
+
+#[cfg(test)]
+mod replay_ut;
 
 use std::collections::HashSet;
 

--- a/libsysproto/src/replay.rs
+++ b/libsysproto/src/replay.rs
@@ -1,0 +1,74 @@
+use crate::{
+    MinionMessage,
+    rqtypes::{ProtoKey, RequestType},
+};
+use libcommon::SysinspectError;
+use serde::Deserialize;
+
+const REPLAY_KIND_EVENT: &str = "evt";
+const REPLAY_KIND_MODEL_EVENT: &str = "mvt";
+const REPLAY_KIND_MODEL_ACK: &str = "mack";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplayIdentity {
+    Event { minion_id: String, cycle_id: String, entity_id: String, session_id: String, action_id: String },
+    ModelEvent { minion_id: String, cycle_id: String },
+    ModelAck { minion_id: String, cycle_id: String },
+}
+
+#[derive(Debug, Deserialize)]
+struct ReplayEventPayload {
+    #[serde(rename = "cid")]
+    cycle_id: String,
+    #[serde(rename = "eid")]
+    entity_id: String,
+    #[serde(rename = "sid")]
+    session_id: String,
+    #[serde(rename = "aid")]
+    action_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReplayModelAckPayload {
+    cycle_id: String,
+}
+
+impl ReplayIdentity {
+    pub fn key(&self) -> String {
+        match self {
+            Self::Event { minion_id, cycle_id, entity_id, session_id, action_id } => {
+                format!("{REPLAY_KIND_EVENT}|{minion_id}|{cycle_id}|{entity_id}|{session_id}|{action_id}")
+            }
+            Self::ModelEvent { minion_id, cycle_id } => format!("{REPLAY_KIND_MODEL_EVENT}|{minion_id}|{cycle_id}"),
+            Self::ModelAck { minion_id, cycle_id } => format!("{REPLAY_KIND_MODEL_ACK}|{minion_id}|{cycle_id}"),
+        }
+    }
+}
+
+pub fn replay_identity_from_minion_message(msg: &MinionMessage) -> Result<Option<ReplayIdentity>, SysinspectError> {
+    Ok(match msg.req_type() {
+        RequestType::Event => {
+            let payload = serde_json::from_value::<ReplayEventPayload>(msg.payload().clone())?;
+            Some(ReplayIdentity::Event {
+                minion_id: msg.id().to_string(),
+                cycle_id: payload.cycle_id,
+                entity_id: payload.entity_id,
+                session_id: payload.session_id,
+                action_id: payload.action_id,
+            })
+        }
+        RequestType::ModelEvent => {
+            let cycle_id = msg.payload().get(ProtoKey::CycleId.to_string()).and_then(|v| v.as_str()).unwrap_or_default().to_string();
+            Some(ReplayIdentity::ModelEvent { minion_id: msg.id().to_string(), cycle_id })
+        }
+        RequestType::ModelAck => {
+            let payload = serde_json::from_value::<ReplayModelAckPayload>(msg.payload().clone())?;
+            Some(ReplayIdentity::ModelAck { minion_id: msg.id().to_string(), cycle_id: payload.cycle_id })
+        }
+        _ => None,
+    })
+}
+
+pub fn replay_identity_from_minion_bytes(raw: &[u8]) -> Result<Option<ReplayIdentity>, SysinspectError> {
+    replay_identity_from_minion_message(&serde_json::from_slice::<MinionMessage>(raw)?)
+}

--- a/libsysproto/src/replay_ut.rs
+++ b/libsysproto/src/replay_ut.rs
@@ -1,0 +1,67 @@
+use crate::{
+    MinionMessage, ProtoConversion,
+    replay::{ReplayIdentity, replay_identity_from_minion_bytes, replay_identity_from_minion_message},
+    rqtypes::RequestType,
+};
+use serde_json::json;
+
+#[test]
+fn event_identity_is_stable_from_message_and_bytes() {
+    let msg = MinionMessage::new(
+        "minion-1".to_string(),
+        RequestType::Event,
+        json!({"eid":"entity-1","aid":"action-1","sid":"session-1","cid":"cycle-1","timestamp":"1"}),
+    );
+
+    let from_msg = replay_identity_from_minion_message(&msg).unwrap().unwrap();
+    let from_bytes = replay_identity_from_minion_bytes(&msg.sendable().unwrap()).unwrap().unwrap();
+
+    assert_eq!(
+        from_msg,
+        ReplayIdentity::Event {
+            minion_id: "minion-1".to_string(),
+            cycle_id: "cycle-1".to_string(),
+            entity_id: "entity-1".to_string(),
+            session_id: "session-1".to_string(),
+            action_id: "action-1".to_string(),
+        }
+    );
+    assert_eq!(from_msg, from_bytes);
+    assert_eq!(from_msg.key(), "evt|minion-1|cycle-1|entity-1|session-1|action-1");
+}
+
+#[test]
+fn model_event_identity_is_stable_from_message_and_bytes() {
+    let msg = MinionMessage::new(
+        "minion-1".to_string(),
+        RequestType::ModelEvent,
+        json!({"eid":"entity-1","aid":"action-1","sid":"session-1","cid":"cycle-1","timestamp":"1"}),
+    );
+
+    let from_msg = replay_identity_from_minion_message(&msg).unwrap().unwrap();
+    let from_bytes = replay_identity_from_minion_bytes(&msg.sendable().unwrap()).unwrap().unwrap();
+
+    assert_eq!(from_msg, ReplayIdentity::ModelEvent { minion_id: "minion-1".to_string(), cycle_id: "cycle-1".to_string() });
+    assert_eq!(from_msg, from_bytes);
+    assert_eq!(from_msg.key(), "mvt|minion-1|cycle-1");
+}
+
+#[test]
+fn model_ack_identity_is_stable_from_message_and_bytes() {
+    let msg = MinionMessage::new("minion-1".to_string(), RequestType::ModelAck, json!({"cycle_id":"cycle-1"}));
+
+    let from_msg = replay_identity_from_minion_message(&msg).unwrap().unwrap();
+    let from_bytes = replay_identity_from_minion_bytes(&msg.sendable().unwrap()).unwrap().unwrap();
+
+    assert_eq!(from_msg, ReplayIdentity::ModelAck { minion_id: "minion-1".to_string(), cycle_id: "cycle-1".to_string() });
+    assert_eq!(from_msg, from_bytes);
+    assert_eq!(from_msg.key(), "mack|minion-1|cycle-1");
+}
+
+#[test]
+fn unsupported_message_type_has_no_replay_identity() {
+    let msg = MinionMessage::new("minion-1".to_string(), RequestType::Ping, json!({}));
+
+    assert!(replay_identity_from_minion_message(&msg).unwrap().is_none());
+    assert!(replay_identity_from_minion_bytes(&msg.sendable().unwrap()).unwrap().is_none());
+}

--- a/libsysproto/src/rqtypes.rs
+++ b/libsysproto/src/rqtypes.rs
@@ -126,4 +126,12 @@ pub enum RequestType {
 
     #[serde(rename = "ssp")]
     SensorsSyncResponse,
+
+    /// Minion→Master: model cycle completed.
+    #[serde(rename = "mack")]
+    ModelAck,
+
+    /// Master→Minion: model cycle acknowledged.
+    #[serde(rename = "cack")]
+    CycleAck,
 }

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -226,6 +226,9 @@ impl SysMaster {
     }
 
     fn duplicate_replay_blocks_processing(identity: &ReplayIdentity) -> bool {
+        // `Event` and `ModelEvent` duplicates must be suppressed before side effects like
+        // telemetry emission. `ModelAck` is different: even if duplicate, it may need to
+        // trigger a fresh `CycleAck` because the minion can miss the earlier ack.
         !matches!(identity, ReplayIdentity::ModelAck { .. })
     }
 

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -137,6 +137,7 @@ pub struct SysMaster {
     ptr: Option<Weak<Mutex<SysMaster>>>,
     vmcluster: VirtualMinionsCluster,
     conn_to_mid: HashMap<String, String>, // Map connection addresses to minion IDs
+    peer_direct_tx: HashMap<String, mpsc::Sender<Vec<u8>>>,
     peer_transport: PeerTransport,
     datastore: Arc<Mutex<DataStorage>>,
 }
@@ -171,6 +172,7 @@ impl SysMaster {
             ptr: None,
             vmcluster,
             conn_to_mid: HashMap::new(),
+            peer_direct_tx: HashMap::new(),
             peer_transport: PeerTransport::new(),
             datastore: Arc::new(Mutex::new(DataStorage::new(ds_cfg, ds_path)?)),
         })
@@ -898,6 +900,23 @@ impl SysMaster {
                     _ = c_bcast.send(guard.msg_sensors_files());
                 });
             }
+            RequestType::ModelAck => {
+                let cycle_id = req.payload().get("cycle_id").and_then(|v| v.as_str()).unwrap_or("?").to_string();
+                let minion_id = req.id().to_string();
+                log::warn!("ACK from minion {} for cycle {}", minion_id, cycle_id);
+
+                let c_master = Arc::clone(&master);
+                let c_addr = minion_addr.clone();
+                tokio::spawn(async move {
+                    let mut guard = c_master.lock().await;
+                    let ack = MasterMessage::new(RequestType::CycleAck, json!({"cycle_id": cycle_id}));
+                    if let Ok(encrypted) = guard.peer_transport.encode_message(&c_addr, &ack) {
+                        if let Some(tx) = guard.peer_direct_tx.get(&c_addr) {
+                            let _ = tx.try_send(encrypted);
+                        }
+                    }
+                });
+            }
             _ => {
                 log::error!("Minion sends unknown request type");
             }
@@ -1267,6 +1286,9 @@ impl SysMaster {
         let c_master_writer = Arc::clone(&master);
         let c_master_reader = Arc::clone(&master);
         let (direct_tx, direct_rx) = mpsc::channel::<Vec<u8>>(8);
+        {
+            master.lock().await.peer_direct_tx.insert(peer_addr.clone(), direct_tx.clone());
+        }
         let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
         let cancel_writer = cancel_tx.clone();
 

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -903,17 +903,19 @@ impl SysMaster {
             RequestType::ModelAck => {
                 let cycle_id = req.payload().get("cycle_id").and_then(|v| v.as_str()).unwrap_or("?").to_string();
                 let minion_id = req.id().to_string();
-                log::warn!("ACK from minion {} for cycle {}", minion_id, cycle_id);
+                log::debug!("ACK from minion {} for cycle {} with payload {}", minion_id, cycle_id, req.payload());
 
                 let c_master = Arc::clone(&master);
                 let c_addr = minion_addr.clone();
                 tokio::spawn(async move {
                     let mut guard = c_master.lock().await;
+                    let label = guard.resolved_peer_label(&minion_id, &c_addr).await;
                     let ack = MasterMessage::new(RequestType::CycleAck, json!({"cycle_id": cycle_id}));
                     if let Ok(encrypted) = guard.peer_transport.encode_message(&c_addr, &ack)
                         && let Some(tx) = guard.peer_direct_tx.get(&c_addr)
                     {
                         let _ = tx.try_send(encrypted);
+                        log::info!("Synced journal with minion {} for cycle {}", label, cycle_id);
                     }
                 });
             }

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -914,8 +914,10 @@ impl SysMaster {
                     if let Ok(encrypted) = guard.peer_transport.encode_message(&c_addr, &ack)
                         && let Some(tx) = guard.peer_direct_tx.get(&c_addr)
                     {
-                        let _ = tx.try_send(encrypted);
-                        log::info!("Synced journal with minion {} for cycle {}", label, cycle_id);
+                        match tx.try_send(encrypted) {
+                            Ok(_) => log::info!("Synced journal with minion {} for cycle {}", label, cycle_id),
+                            Err(e) => log::warn!("Failed to send journal ack to {}: {}", label, e),
+                        }
                     }
                 });
             }

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -70,6 +70,10 @@ pub static SHARED_SESSION: Lazy<Arc<Mutex<SessionKeeper>>> = Lazy::new(|| Arc::n
 static MODEL_CACHE: Lazy<Arc<Mutex<HashMap<PathBuf, ModelSpec>>>> = Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
 const DEFAULT_ROTATION_OVERLAP_SECONDS: u64 = 900;
 
+const REPLAY_KIND_EVENT: &str = "evt";
+const REPLAY_KIND_MODEL_EVENT: &str = "mvt";
+const REPLAY_KIND_MODEL_ACK: &str = "mack";
+
 #[derive(Debug, Clone, Deserialize)]
 struct RotationConsoleRequest {
     op: Option<String>,
@@ -217,6 +221,51 @@ impl SysMaster {
     #[cfg(test)]
     pub(crate) fn peer_rate_limit_key_for_test(peer_addr: &str) -> String {
         PeerTransport::rate_limit_key(peer_addr)
+    }
+
+    fn replay_identity(kind: &str, parts: &[&str]) -> String {
+        let mut key = String::from(kind);
+        for part in parts {
+            key.push('|');
+            key.push_str(part);
+        }
+        key
+    }
+
+    fn event_replay_key(minion_id: &str, payload: &HashMap<String, serde_json::Value>) -> String {
+        Self::replay_identity(
+            REPLAY_KIND_EVENT,
+            &[
+                minion_id,
+                &util::dataconv::as_str(payload.get(&ProtoKey::CycleId.to_string()).cloned()),
+                &util::dataconv::as_str(payload.get(&ProtoKey::EntityId.to_string()).cloned()),
+                &util::dataconv::as_str(payload.get(&ProtoKey::SessionId.to_string()).cloned()),
+                &util::dataconv::as_str(payload.get(&ProtoKey::ActionId.to_string()).cloned()),
+            ],
+        )
+    }
+
+    fn model_event_replay_key(minion_id: &str, payload: &HashMap<String, serde_json::Value>) -> String {
+        Self::replay_identity(REPLAY_KIND_MODEL_EVENT, &[minion_id, &util::dataconv::as_str(payload.get(&ProtoKey::CycleId.to_string()).cloned())])
+    }
+
+    fn model_ack_replay_key(minion_id: &str, cycle_id: &str) -> String {
+        Self::replay_identity(REPLAY_KIND_MODEL_ACK, &[minion_id, cycle_id])
+    }
+
+    #[cfg(test)]
+    pub(crate) fn event_replay_key_for_test(minion_id: &str, payload: &HashMap<String, serde_json::Value>) -> String {
+        Self::event_replay_key(minion_id, payload)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn model_event_replay_key_for_test(minion_id: &str, payload: &HashMap<String, serde_json::Value>) -> String {
+        Self::model_event_replay_key(minion_id, payload)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn model_ack_replay_key_for_test(minion_id: &str, cycle_id: &str) -> String {
+        Self::model_ack_replay_key(minion_id, cycle_id)
     }
 
     #[cfg(test)]
@@ -810,6 +859,19 @@ impl SysMaster {
                         }
                     };
 
+                    let replay_key = Self::event_replay_key(req.id(), &pl);
+                    match m.evtipc.claim_replay_key(&replay_key).await {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            log::debug!("Dropped duplicate Event replay for {} with key {}", req.id(), replay_key);
+                            return;
+                        }
+                        Err(err) => {
+                            log::error!("Failed to claim Event replay key for {}: {}", req.id(), err);
+                            return;
+                        }
+                    }
+
                     if m.cfg().telemetry_enabled() {
                         OtelLogger::new(&pl).log(&mrec, DataExportType::Action);
                     }
@@ -861,6 +923,18 @@ impl SysMaster {
                             return;
                         }
                     };
+                    let replay_key = Self::model_event_replay_key(req.id(), &pl);
+                    match master.evtipc.claim_replay_key(&replay_key).await {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            log::debug!("Dropped duplicate ModelEvent replay for {} with key {}", req.id(), replay_key);
+                            return;
+                        }
+                        Err(err) => {
+                            log::error!("Failed to claim ModelEvent replay key for {}: {}", req.id(), err);
+                            return;
+                        }
+                    }
                     let sid = match master.evtipc.get_session(&util::dataconv::as_str(pl.get(&ProtoKey::CycleId.to_string()).cloned())).await {
                         Ok(sid) => sid,
                         Err(err) => {
@@ -909,6 +983,18 @@ impl SysMaster {
                 let c_addr = minion_addr.clone();
                 tokio::spawn(async move {
                     let mut guard = c_master.lock().await;
+                    let replay_key = Self::model_ack_replay_key(&minion_id, &cycle_id);
+                    match guard.evtipc.claim_replay_key(&replay_key).await {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            log::debug!("Dropped duplicate ModelAck replay for {} with key {}", minion_id, replay_key);
+                            return;
+                        }
+                        Err(err) => {
+                            log::error!("Failed to claim ModelAck replay key for {}: {}", minion_id, err);
+                            return;
+                        }
+                    }
                     let label = guard.resolved_peer_label(&minion_id, &c_addr).await;
                     let ack = MasterMessage::new(RequestType::CycleAck, json!({"cycle_id": cycle_id}));
                     if let Ok(encrypted) = guard.peer_transport.encode_message(&c_addr, &ack)

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -910,10 +910,10 @@ impl SysMaster {
                 tokio::spawn(async move {
                     let mut guard = c_master.lock().await;
                     let ack = MasterMessage::new(RequestType::CycleAck, json!({"cycle_id": cycle_id}));
-                    if let Ok(encrypted) = guard.peer_transport.encode_message(&c_addr, &ack) {
-                        if let Some(tx) = guard.peer_direct_tx.get(&c_addr) {
-                            let _ = tx.try_send(encrypted);
-                        }
+                    if let Ok(encrypted) = guard.peer_transport.encode_message(&c_addr, &ack)
+                        && let Some(tx) = guard.peer_direct_tx.get(&c_addr)
+                    {
+                        let _ = tx.try_send(encrypted);
                     }
                 });
             }

--- a/sysmaster/src/master.rs
+++ b/sysmaster/src/master.rs
@@ -42,6 +42,7 @@ use libsysproto::{
             CLUSTER_ROTATE, CLUSTER_TRAITS_UPDATE, CLUSTER_TRANSPORT_STATUS,
         },
     },
+    replay::{ReplayIdentity, replay_identity_from_minion_message},
     rqtypes::{ProtoKey, ProtoValue, RequestType},
     secure::SECURE_PROTOCOL_VERSION,
 };
@@ -69,10 +70,6 @@ use tokio::time::{Duration, sleep};
 pub static SHARED_SESSION: Lazy<Arc<Mutex<SessionKeeper>>> = Lazy::new(|| Arc::new(Mutex::new(SessionKeeper::new(30))));
 static MODEL_CACHE: Lazy<Arc<Mutex<HashMap<PathBuf, ModelSpec>>>> = Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
 const DEFAULT_ROTATION_OVERLAP_SECONDS: u64 = 900;
-
-const REPLAY_KIND_EVENT: &str = "evt";
-const REPLAY_KIND_MODEL_EVENT: &str = "mvt";
-const REPLAY_KIND_MODEL_ACK: &str = "mack";
 
 #[derive(Debug, Clone, Deserialize)]
 struct RotationConsoleRequest {
@@ -223,49 +220,18 @@ impl SysMaster {
         PeerTransport::rate_limit_key(peer_addr)
     }
 
-    fn replay_identity(kind: &str, parts: &[&str]) -> String {
-        let mut key = String::from(kind);
-        for part in parts {
-            key.push('|');
-            key.push_str(part);
-        }
-        key
+    #[cfg(test)]
+    pub(crate) fn replay_identity_key_for_test(msg: &MinionMessage) -> Option<String> {
+        replay_identity_from_minion_message(msg).ok().flatten().map(|identity| identity.key())
     }
 
-    fn event_replay_key(minion_id: &str, payload: &HashMap<String, serde_json::Value>) -> String {
-        Self::replay_identity(
-            REPLAY_KIND_EVENT,
-            &[
-                minion_id,
-                &util::dataconv::as_str(payload.get(&ProtoKey::CycleId.to_string()).cloned()),
-                &util::dataconv::as_str(payload.get(&ProtoKey::EntityId.to_string()).cloned()),
-                &util::dataconv::as_str(payload.get(&ProtoKey::SessionId.to_string()).cloned()),
-                &util::dataconv::as_str(payload.get(&ProtoKey::ActionId.to_string()).cloned()),
-            ],
-        )
-    }
-
-    fn model_event_replay_key(minion_id: &str, payload: &HashMap<String, serde_json::Value>) -> String {
-        Self::replay_identity(REPLAY_KIND_MODEL_EVENT, &[minion_id, &util::dataconv::as_str(payload.get(&ProtoKey::CycleId.to_string()).cloned())])
-    }
-
-    fn model_ack_replay_key(minion_id: &str, cycle_id: &str) -> String {
-        Self::replay_identity(REPLAY_KIND_MODEL_ACK, &[minion_id, cycle_id])
+    fn duplicate_replay_blocks_processing(identity: &ReplayIdentity) -> bool {
+        !matches!(identity, ReplayIdentity::ModelAck { .. })
     }
 
     #[cfg(test)]
-    pub(crate) fn event_replay_key_for_test(minion_id: &str, payload: &HashMap<String, serde_json::Value>) -> String {
-        Self::event_replay_key(minion_id, payload)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn model_event_replay_key_for_test(minion_id: &str, payload: &HashMap<String, serde_json::Value>) -> String {
-        Self::model_event_replay_key(minion_id, payload)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn model_ack_replay_key_for_test(minion_id: &str, cycle_id: &str) -> String {
-        Self::model_ack_replay_key(minion_id, cycle_id)
+    pub(crate) fn duplicate_replay_blocks_processing_for_test(identity: &ReplayIdentity) -> bool {
+        Self::duplicate_replay_blocks_processing(identity)
     }
 
     #[cfg(test)]
@@ -859,7 +825,20 @@ impl SysMaster {
                         }
                     };
 
-                    let replay_key = Self::event_replay_key(req.id(), &pl);
+                    let replay_key = match replay_identity_from_minion_message(&req) {
+                        Ok(Some(ReplayIdentity::Event { .. })) => {
+                            replay_identity_from_minion_message(&req).ok().flatten().map(|identity| identity.key())
+                        }
+                        Ok(_) => None,
+                        Err(err) => {
+                            log::error!("Failed to derive Event replay identity for {}: {}", req.id(), err);
+                            return;
+                        }
+                    };
+                    let Some(replay_key) = replay_key else {
+                        log::error!("Missing Event replay identity for {}", req.id());
+                        return;
+                    };
                     match m.evtipc.claim_replay_key(&replay_key).await {
                         Ok(true) => {}
                         Ok(false) => {
@@ -923,7 +902,20 @@ impl SysMaster {
                             return;
                         }
                     };
-                    let replay_key = Self::model_event_replay_key(req.id(), &pl);
+                    let replay_key = match replay_identity_from_minion_message(&req) {
+                        Ok(Some(ReplayIdentity::ModelEvent { .. })) => {
+                            replay_identity_from_minion_message(&req).ok().flatten().map(|identity| identity.key())
+                        }
+                        Ok(_) => None,
+                        Err(err) => {
+                            log::error!("Failed to derive ModelEvent replay identity for {}: {}", req.id(), err);
+                            return;
+                        }
+                    };
+                    let Some(replay_key) = replay_key else {
+                        log::error!("Missing ModelEvent replay identity for {}", req.id());
+                        return;
+                    };
                     match master.evtipc.claim_replay_key(&replay_key).await {
                         Ok(true) => {}
                         Ok(false) => {
@@ -983,12 +975,27 @@ impl SysMaster {
                 let c_addr = minion_addr.clone();
                 tokio::spawn(async move {
                     let mut guard = c_master.lock().await;
-                    let replay_key = Self::model_ack_replay_key(&minion_id, &cycle_id);
+                    let replay_identity = match replay_identity_from_minion_message(&req) {
+                        Ok(Some(identity @ ReplayIdentity::ModelAck { .. })) => Some(identity),
+                        Ok(_) => None,
+                        Err(err) => {
+                            log::error!("Failed to derive ModelAck replay identity for {}: {}", minion_id, err);
+                            return;
+                        }
+                    };
+                    let Some(replay_identity) = replay_identity else {
+                        log::error!("Missing ModelAck replay identity for {}", minion_id);
+                        return;
+                    };
+                    let replay_key = replay_identity.key();
                     match guard.evtipc.claim_replay_key(&replay_key).await {
                         Ok(true) => {}
                         Ok(false) => {
-                            log::debug!("Dropped duplicate ModelAck replay for {} with key {}", minion_id, replay_key);
-                            return;
+                            if Self::duplicate_replay_blocks_processing(&replay_identity) {
+                                log::debug!("Dropped duplicate ModelAck replay for {} with key {}", minion_id, replay_key);
+                                return;
+                            }
+                            log::debug!("Received duplicate ModelAck replay for {} with key {}; re-sending CycleAck", minion_id, replay_key);
                         }
                         Err(err) => {
                             log::error!("Failed to claim ModelAck replay key for {}: {}", minion_id, err);

--- a/sysmaster/src/master_ut.rs
+++ b/sysmaster/src/master_ut.rs
@@ -1,6 +1,8 @@
 use crate::master::SysMaster;
 use chrono::Utc;
+use libeventreg::{ipcs::DbIPCService, kvdb::EventsRegistry};
 use libsysinspect::{
+    cfg::mmconf::HistoryConfig,
     rsa::keys::{get_fingerprint, keygen},
     transport::{
         TransportKeyExchangeModel, TransportPeerState, TransportProvisioningMode, TransportRotationStatus, secure_bootstrap::SecureBootstrapSession,
@@ -12,7 +14,8 @@ use libsysproto::secure::{
 };
 use rsa::RsaPublicKey;
 use serde_json::json;
-use std::{collections::HashMap, time::Instant};
+use std::{collections::HashMap, sync::Arc, time::Instant};
+use tokio::sync::Mutex;
 
 fn fresh_timestamp() -> i64 {
     Utc::now().timestamp()
@@ -235,4 +238,35 @@ fn invalid_hello_does_not_poison_replay_cache_then_valid_retry_is_accepted() {
         .unwrap(),
         SecureFrame::BootstrapDiagnostic(frame) if frame.message.contains("replay")
     ));
+}
+
+#[test]
+fn event_replay_key_uses_stable_minion_cycle_entity_session_action_identity() {
+    let payload = HashMap::from([
+        ("cid".to_string(), json!("cycle-1")),
+        ("eid".to_string(), json!("entity-1")),
+        ("sid".to_string(), json!("session-1")),
+        ("aid".to_string(), json!("action-1")),
+    ]);
+
+    assert_eq!(SysMaster::event_replay_key_for_test("minion-1", &payload), "evt|minion-1|cycle-1|entity-1|session-1|action-1");
+}
+
+#[test]
+fn model_event_and_ack_replay_keys_are_distinct() {
+    let payload = HashMap::from([("cid".to_string(), json!("cycle-1"))]);
+
+    assert_eq!(SysMaster::model_event_replay_key_for_test("minion-1", &payload), "mvt|minion-1|cycle-1");
+    assert_eq!(SysMaster::model_ack_replay_key_for_test("minion-1", "cycle-1"), "mack|minion-1|cycle-1");
+}
+
+#[tokio::test]
+async fn replay_claim_rejects_duplicate_identity_across_calls() {
+    let tmp = tempfile::tempdir().unwrap();
+    let evtreg = Arc::new(Mutex::new(EventsRegistry::new(tmp.path().join("telemetry"), HistoryConfig::default()).unwrap()));
+    let service = DbIPCService::new(evtreg, tmp.path().join("telemetry.sock").to_str().unwrap()).unwrap();
+    let key = "evt|minion-1|cycle-1|entity-1|session-1|action-1";
+
+    assert!(service.claim_replay_key(key).await.unwrap());
+    assert!(!service.claim_replay_key(key).await.unwrap());
 }

--- a/sysmaster/src/master_ut.rs
+++ b/sysmaster/src/master_ut.rs
@@ -12,6 +12,7 @@ use libsysinspect::{
 use libsysproto::secure::{
     SECURE_PROTOCOL_VERSION, SECURE_SUPPORTED_PROTOCOL_VERSIONS, SecureBootstrapHello, SecureDiagnosticCode, SecureFrame, SecureSessionBinding,
 };
+use libsysproto::{MinionMessage, replay::ReplayIdentity, rqtypes::RequestType};
 use rsa::RsaPublicKey;
 use serde_json::json;
 use std::{collections::HashMap, sync::Arc, time::Instant};
@@ -242,22 +243,45 @@ fn invalid_hello_does_not_poison_replay_cache_then_valid_retry_is_accepted() {
 
 #[test]
 fn event_replay_key_uses_stable_minion_cycle_entity_session_action_identity() {
-    let payload = HashMap::from([
-        ("cid".to_string(), json!("cycle-1")),
-        ("eid".to_string(), json!("entity-1")),
-        ("sid".to_string(), json!("session-1")),
-        ("aid".to_string(), json!("action-1")),
-    ]);
+    let msg = MinionMessage::new(
+        "minion-1".to_string(),
+        RequestType::Event,
+        json!({"cid":"cycle-1","eid":"entity-1","sid":"session-1","aid":"action-1","timestamp":"1"}),
+    );
 
-    assert_eq!(SysMaster::event_replay_key_for_test("minion-1", &payload), "evt|minion-1|cycle-1|entity-1|session-1|action-1");
+    assert_eq!(SysMaster::replay_identity_key_for_test(&msg).unwrap(), "evt|minion-1|cycle-1|entity-1|session-1|action-1");
 }
 
 #[test]
 fn model_event_and_ack_replay_keys_are_distinct() {
-    let payload = HashMap::from([("cid".to_string(), json!("cycle-1"))]);
+    let model_event = MinionMessage::new(
+        "minion-1".to_string(),
+        RequestType::ModelEvent,
+        json!({"cid":"cycle-1","eid":"entity-1","sid":"session-1","aid":"action-1","timestamp":"1"}),
+    );
+    let model_ack = MinionMessage::new("minion-1".to_string(), RequestType::ModelAck, json!({"cycle_id":"cycle-1"}));
 
-    assert_eq!(SysMaster::model_event_replay_key_for_test("minion-1", &payload), "mvt|minion-1|cycle-1");
-    assert_eq!(SysMaster::model_ack_replay_key_for_test("minion-1", "cycle-1"), "mack|minion-1|cycle-1");
+    assert_eq!(SysMaster::replay_identity_key_for_test(&model_event).unwrap(), "mvt|minion-1|cycle-1");
+    assert_eq!(SysMaster::replay_identity_key_for_test(&model_ack).unwrap(), "mack|minion-1|cycle-1");
+}
+
+#[test]
+fn duplicate_model_ack_still_allows_cycle_ack_resend() {
+    assert!(SysMaster::duplicate_replay_blocks_processing_for_test(&ReplayIdentity::Event {
+        minion_id: "minion-1".to_string(),
+        cycle_id: "cycle-1".to_string(),
+        entity_id: "entity-1".to_string(),
+        session_id: "session-1".to_string(),
+        action_id: "action-1".to_string(),
+    }));
+    assert!(SysMaster::duplicate_replay_blocks_processing_for_test(&ReplayIdentity::ModelEvent {
+        minion_id: "minion-1".to_string(),
+        cycle_id: "cycle-1".to_string(),
+    }));
+    assert!(!SysMaster::duplicate_replay_blocks_processing_for_test(&ReplayIdentity::ModelAck {
+        minion_id: "minion-1".to_string(),
+        cycle_id: "cycle-1".to_string(),
+    }));
 }
 
 #[tokio::test]

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -84,6 +84,24 @@ use uuid::Uuid;
 
 const RUNNER_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 
+#[derive(Debug, Clone, Copy, Default)]
+struct BacklogSnapshot {
+    journal_cycles: usize,
+    journal_entries: usize,
+    journal_bytes: u64,
+    dpq_pending: usize,
+    dpq_inflight: usize,
+}
+
+impl BacklogSnapshot {
+    fn format(self) -> String {
+        format!(
+            "journal={}/{} entries ({} bytes), dpq={}/{} pending/inflight",
+            self.journal_cycles, self.journal_entries, self.journal_bytes, self.dpq_pending, self.dpq_inflight
+        )
+    }
+}
+
 /// Session Id of the minion
 pub static MINION_SID: Lazy<String> = Lazy::new(|| Uuid::new_v4().to_string());
 
@@ -174,6 +192,18 @@ pub struct SysMinion {
 }
 
 impl SysMinion {
+    fn backlog_snapshot(&self) -> BacklogSnapshot {
+        let journal = self.journal.stats().unwrap_or_default();
+        let dpq = self.dpq.stats();
+        BacklogSnapshot {
+            journal_cycles: journal.pending_cycles,
+            journal_entries: journal.pending_entries,
+            journal_bytes: journal.pending_bytes,
+            dpq_pending: dpq.pending_jobs,
+            dpq_inflight: dpq.inflight_jobs,
+        }
+    }
+
     fn cleanup_empty_sensor_dirs(root: &Path, dir: &Path) {
         let Ok(rd) = fs::read_dir(dir) else {
             return;
@@ -343,7 +373,7 @@ impl SysMinion {
         };
 
         if let Err(err) = self.write_frame(&payload).await {
-            log::warn!("Failed to send message to master: {err}; triggering reconnect");
+            log::warn!("Failed to send message to master: {err}; triggering reconnect; backlog: {}", self.backlog_snapshot().format());
             let _ = CONNECTION_TX.send(());
             return Err(err);
         }
@@ -487,7 +517,7 @@ impl SysMinion {
                     }
 
                     if this.last_ping.lock().await.elapsed() > this.ping_timeout {
-                        log::warn!("Master seems unresponsive, triggering reconnect.");
+                        log::warn!("Master seems unresponsive, triggering reconnect. Backlog: {}", this.backlog_snapshot().format());
                         let _ = reconnect_sender.send(());
                         state.exit.store(true, Ordering::Relaxed);
                         break;
@@ -623,7 +653,7 @@ impl SysMinion {
                 let msg = match this.read_frame().await {
                     Ok(msg) => msg,
                     Err(err) => {
-                        log::warn!("Proto read failed: {err}; triggering reconnect");
+                        log::warn!("Proto read failed: {err}; triggering reconnect; backlog: {}", this.backlog_snapshot().format());
                         let _ = CONNECTION_TX.send(());
                         break;
                     }
@@ -730,7 +760,14 @@ impl SysMinion {
                     RequestType::CycleAck => {
                         let cycle_id = msg.payload().get("cycle_id").and_then(|v| v.as_str()).unwrap_or("?");
                         match this.journal.ack_cycle(cycle_id) {
-                            Ok(n) if n > 0 => log::info!("Journal freed {} entries for cycle {}", n, cycle_id),
+                            Ok(n) if n > 0 => {
+                                log::info!(
+                                    "Journal freed {} entries for cycle {}; remaining backlog: {}",
+                                    n,
+                                    cycle_id,
+                                    this.backlog_snapshot().format()
+                                )
+                            }
                             Ok(_) => log::debug!("Journal cycle {} already acked", cycle_id),
                             Err(err) => log::error!("Failed to ack journal cycle {}: {}", cycle_id, err),
                         }
@@ -987,6 +1024,7 @@ impl SysMinion {
     async fn replay_pending(self: Arc<Self>) {
         match self.journal.pending() {
             Ok(cycles) => {
+                let before = self.backlog_snapshot();
                 let cycle_count = cycles.len();
                 let mut total_entries = 0usize;
                 for (cycle_id, entries) in &cycles {
@@ -1000,7 +1038,12 @@ impl SysMinion {
                     }
                 }
                 if total_entries > 0 {
-                    log::info!("Resent {} journal entries from {} cycle(s) to master", total_entries, cycle_count);
+                    log::info!(
+                        "Resent {} journal entries from {} cycle(s) to master; backlog before replay: {}",
+                        total_entries,
+                        cycle_count,
+                        before.format()
+                    );
                 }
             }
             Err(e) => log::error!("Failed to read pending journal entries: {}", e),
@@ -1556,7 +1599,7 @@ pub async fn minion(cfg: MinionConfig, fp: Option<String>) {
         }
 
         let interval = cfg.reconnect_interval();
-        log::info!("Reconnecting in {interval} seconds...");
+        log::info!("Reconnecting in {interval} seconds... Current backlog: {}", dpq.stats().format());
         sleep(Duration::from_secs(interval)).await;
     }
 }

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -81,6 +81,8 @@ use tokio::{
 };
 use uuid::Uuid;
 
+const RUNNER_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Session Id of the minion
 pub static MINION_SID: Lazy<String> = Lazy::new(|| Uuid::new_v4().to_string());
 
@@ -325,22 +327,27 @@ impl SysMinion {
 
     /// Talk-back to the master
     pub(crate) async fn request(&self, msg: Vec<u8>) {
+        let _ = self.try_request(msg).await;
+    }
+
+    async fn try_request(&self, msg: Vec<u8>) -> Result<(), SysinspectError> {
         let payload = match self.secure.lock().await.as_mut().map(|secure| secure.seal_bytes(&msg)).transpose() {
             Ok(Some(msg)) => msg,
             Ok(None) => msg,
             Err(err) => {
                 log::error!("Failed to encode secure payload to master: {err}");
                 let _ = CONNECTION_TX.send(());
-                return;
+                return Err(err);
             }
         };
 
         if let Err(err) = self.write_frame(&payload).await {
             log::warn!("Failed to send message to master: {err}; triggering reconnect");
             let _ = CONNECTION_TX.send(());
-        } else {
-            log::trace!("To master: {}", String::from_utf8_lossy(&payload));
+            return Err(err);
         }
+        log::trace!("To master: {}", String::from_utf8_lossy(&payload));
+        Ok(())
     }
 
     /// Write one length-prefixed transport frame to the master connection.
@@ -721,9 +728,10 @@ impl SysMinion {
 
                     RequestType::CycleAck => {
                         let cycle_id = msg.payload().get("cycle_id").and_then(|v| v.as_str()).unwrap_or("?");
-                        log::debug!("ACK from master on {:?} with payload {}", cycle_id, msg.payload());
-                        if let Err(err) = this.journal.ack_cycle(cycle_id) {
-                            log::error!("Failed to ack journal cycle {}: {}", cycle_id, err);
+                        match this.journal.ack_cycle(cycle_id) {
+                            Ok(n) if n > 0 => log::info!("Journal freed {} entries for cycle {}", n, cycle_id),
+                            Ok(_) => log::debug!("Journal cycle {} already acked", cycle_id),
+                            Err(err) => log::error!("Failed to ack journal cycle {}: {}", cycle_id, err),
                         }
                     }
 
@@ -766,6 +774,10 @@ impl SysMinion {
                             Ok(_) => {
                                 log::info!("Connected");
                                 this.set_connected(true);
+                                let this = this.clone();
+                                tokio::spawn(async move {
+                                    this.replay_pending().await;
+                                });
                             }
                             Err(err) => log::error!("Unable to send traits: {err}"),
                         }
@@ -940,8 +952,53 @@ impl SysMinion {
     async fn send_model_ack(self: &Arc<Self>, cycle_id: &str) {
         let r = MinionMessage::new(self.get_minion_id().to_string(), RequestType::ModelAck, json!({"cycle_id": cycle_id}));
         match r.sendable() {
-            Ok(msg) => self.request(msg).await,
+            Ok(msg) => {
+                if let Err(e) = self.journal.append(cycle_id, &msg) {
+                    log::error!("Failed to journal model ack for cycle {}: {}", cycle_id, e);
+                }
+                self.request(msg).await
+            }
             Err(e) => log::error!("Failed to send model ack: {e}"),
+        }
+    }
+
+    fn pending_cycle_needs_model_ack(entries: &[(u64, Vec<u8>)]) -> bool {
+        let mut has_model_event = false;
+        let mut has_model_ack = false;
+
+        for (_, payload) in entries {
+            if let Ok(msg) = serde_json::from_slice::<MinionMessage>(payload) {
+                match msg.req_type() {
+                    RequestType::ModelEvent => has_model_event = true,
+                    RequestType::ModelAck => has_model_ack = true,
+                    _ => {}
+                }
+            }
+        }
+
+        has_model_event && !has_model_ack
+    }
+
+    async fn replay_pending(self: Arc<Self>) {
+        match self.journal.pending() {
+            Ok(cycles) => {
+                let cycle_count = cycles.len();
+                let mut total_entries = 0usize;
+                for (cycle_id, entries) in &cycles {
+                    for (_seq, payload) in entries {
+                        if self.try_request(payload.clone()).await.is_ok() {
+                            total_entries += 1;
+                        }
+                    }
+                    if Self::pending_cycle_needs_model_ack(entries) {
+                        self.send_model_ack(cycle_id).await;
+                    }
+                }
+                if total_entries > 0 {
+                    log::info!("Resent {} journal entries from {} cycle(s) to master", total_entries, cycle_count);
+                }
+            }
+            Err(e) => log::error!("Failed to read pending journal entries: {}", e),
         }
     }
 
@@ -1276,9 +1333,26 @@ pub(crate) async fn _minion_instance(cfg: MinionConfig, fingerprint: Option<Stri
         }
     });
 
+    async fn wait_for_runner_drain(minion: &Arc<SysMinion>) {
+        let start = Instant::now();
+        loop {
+            if minion.pt_counter.lock().await.is_done() {
+                // Let the queue runner finish the ack path for the just-completed job.
+                sleep(Duration::from_millis(100)).await;
+                break;
+            }
+            if start.elapsed() >= RUNNER_DRAIN_TIMEOUT {
+                log::warn!("Timed out waiting for in-flight minion work to finish; forcing runner shutdown.");
+                break;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    }
+
     async fn stop_instance(minion: &Arc<SysMinion>, runner: tokio::task::JoinHandle<()>) -> Result<(), tokio::task::JoinError> {
         minion.as_ptr().stop_sensors().await;
         minion.as_ptr().stop_background().await;
+        wait_for_runner_drain(minion).await;
         runner.abort();
         runner.await
     }
@@ -1316,23 +1390,6 @@ pub(crate) async fn _minion_instance(cfg: MinionConfig, fingerprint: Option<Stri
         }
         minion.as_ptr().do_proto().await?;
         minion.as_ptr().send_ehlo().await?;
-        match minion.as_ptr().journal.pending() {
-            Ok(cycles) => {
-                let cycle_count = cycles.len();
-                let mut total_entries = 0usize;
-                for (cycle_id, entries) in &cycles {
-                    for (_seq, payload) in entries {
-                        minion.as_ptr().request(payload.clone()).await;
-                        total_entries += 1;
-                    }
-                    minion.as_ptr().send_model_ack(cycle_id).await;
-                }
-                if total_entries > 0 {
-                    log::info!("Resent {} journal entries from {} cycle(s) to master", total_entries, cycle_count);
-                }
-            }
-            Err(e) => log::error!("Failed to read pending journal entries: {}", e),
-        }
         if cfg.autosync_startup() {
             tokio::select! {
                 sync_res = modpak.sync() => {
@@ -1361,6 +1418,7 @@ pub(crate) async fn _minion_instance(cfg: MinionConfig, fingerprint: Option<Stri
     }
 
     if state.exit.load(Ordering::Relaxed) {
+        wait_for_runner_drain(&minion).await;
         runner.abort();
         let _ = runner.await;
         return Ok(());
@@ -1395,6 +1453,7 @@ pub(crate) async fn _minion_instance(cfg: MinionConfig, fingerprint: Option<Stri
     minion.as_ptr().stop_sensors().await;
     minion.as_ptr().stop_background().await;
 
+    wait_for_runner_drain(&minion).await;
     runner.abort();
     let _ = runner.await;
 
@@ -1441,11 +1500,11 @@ pub async fn minion(cfg: MinionConfig, fp: Option<String>) {
             sig = reconnect_rx.recv() => {
                 match sig {
                     Ok(_) => {
-                        log::warn!("Reconnect signal received; aborting current minion instance.");
+                        log::warn!("Reconnect signal received; waiting for current minion instance to stop.");
                         let _ = mhdl.await;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                        log::warn!("Missed {n} reconnect notification(s) in supervisor loop; aborting current minion instance.");
+                        log::warn!("Missed {n} reconnect notification(s) in supervisor loop; waiting for current minion instance to stop.");
                         let _ = mhdl.await;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -716,6 +716,11 @@ impl SysMinion {
                         break;
                     }
 
+                    RequestType::CycleAck => {
+                        let cycle_id = msg.payload().get("cycle_id").and_then(|v| v.as_str()).unwrap_or("?");
+                        log::warn!("ACK from master on {:?}", cycle_id);
+                    }
+
                     RequestType::Command => {
                         log::debug!("Master sends a command");
                         match msg.get_retcode() {
@@ -921,6 +926,19 @@ impl SysMinion {
         }
     }
 
+    /// Send model completion ACK to master.
+    async fn send_model_ack(self: &Arc<Self>, cycle_id: &str) {
+        let r = MinionMessage::new(
+            self.get_minion_id().to_string(),
+            RequestType::ModelAck,
+            json!({"cycle_id": cycle_id}),
+        );
+        match r.sendable() {
+            Ok(msg) => self.request(msg).await,
+            Err(e) => log::error!("Failed to send model ack: {e}"),
+        }
+    }
+
     async fn apply_rotation_command(self: Arc<Self>, context: &str) -> Result<(), SysinspectError> {
         let payload: RotationCommandPayload =
             serde_json::from_str(context).map_err(|err| SysinspectError::DeserializationError(format!("Failed to parse rotate payload: {err}")))?;
@@ -1097,6 +1115,7 @@ impl SysMinion {
                     log::error!("Blocking task crashed: {e}");
                 }
             };
+            self.as_ptr().send_model_ack(cycle_id).await;
             self.as_ptr().pt_counter.lock().await.dec(cycle_id);
         }
     }

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -31,6 +31,7 @@ use libsysinspect::{
         actproc::{modfinder::ModCall, response::ActionResponse},
         inspector::SysInspector,
     },
+    journal::Journal,
     mdescr::mspecdef::ModelSpec,
     reactor::{
         evtproc::EventProcessor,
@@ -155,6 +156,7 @@ pub struct SysMinion {
 
     pt_counter: Mutex<PTCounter>,
     dpq: Arc<DiskPersistentQueue>,
+    journal: Journal,
     connected: AtomicBool,
     secure: Mutex<Option<SecureChannel>>,
 
@@ -208,6 +210,7 @@ impl SysMinion {
             ping_timeout: Duration::from_secs(10),
             pt_counter: Mutex::new(PTCounter::new()),
             dpq,
+            journal: Journal::open(cfg.journal_path(), cfg.journal_max_bytes())?,
             connected: AtomicBool::new(false),
             secure: Mutex::new(None),
             minion_id: dataconv::as_str(SystemTraits::new(cfg.clone(), true).get(traits::SYS_ID)),
@@ -718,7 +721,10 @@ impl SysMinion {
 
                     RequestType::CycleAck => {
                         let cycle_id = msg.payload().get("cycle_id").and_then(|v| v.as_str()).unwrap_or("?");
-                        log::warn!("ACK from master on {:?}", cycle_id);
+                        log::debug!("ACK from master on {:?} with payload {}", cycle_id, msg.payload());
+                        if let Err(err) = this.journal.ack_cycle(cycle_id) {
+                            log::error!("Failed to ack journal cycle {}: {}", cycle_id, err);
+                        }
                     }
 
                     RequestType::Command => {
@@ -896,14 +902,18 @@ impl SysMinion {
     pub async fn send_callback(self: Arc<Self>, ar: ActionResponse) -> Result<(), SysinspectError> {
         log::debug!("Sending sync callback on {}", ar.aid());
         log::debug!("Callback: {ar:#?}");
-        self.request(MinionMessage::new(self.get_minion_id().to_string(), RequestType::Event, json!(ar)).sendable()?).await;
+        let msg = MinionMessage::new(self.get_minion_id().to_string(), RequestType::Event, json!(ar)).sendable()?;
+        self.journal.append(ar.cid(), &msg)?;
+        self.request(msg).await;
         Ok(())
     }
 
     /// Send finalisation marker callback to the master on the results
     pub async fn send_fin_callback(self: Arc<Self>, ar: ActionResponse) -> Result<(), SysinspectError> {
         log::debug!("Sending fin sync callback on {}", ar.aid());
-        self.request(MinionMessage::new(self.get_minion_id().to_string(), RequestType::ModelEvent, json!(ar)).sendable()?).await;
+        let msg = MinionMessage::new(self.get_minion_id().to_string(), RequestType::ModelEvent, json!(ar)).sendable()?;
+        self.journal.append(ar.cid(), &msg)?;
+        self.request(msg).await;
         Ok(())
     }
 
@@ -1306,6 +1316,23 @@ pub(crate) async fn _minion_instance(cfg: MinionConfig, fingerprint: Option<Stri
         }
         minion.as_ptr().do_proto().await?;
         minion.as_ptr().send_ehlo().await?;
+        match minion.as_ptr().journal.pending() {
+            Ok(cycles) => {
+                let cycle_count = cycles.len();
+                let mut total_entries = 0usize;
+                for (cycle_id, entries) in &cycles {
+                    for (_seq, payload) in entries {
+                        minion.as_ptr().request(payload.clone()).await;
+                        total_entries += 1;
+                    }
+                    minion.as_ptr().send_model_ack(cycle_id).await;
+                }
+                if total_entries > 0 {
+                    log::info!("Resent {} journal entries from {} cycle(s) to master", total_entries, cycle_count);
+                }
+            }
+            Err(e) => log::error!("Failed to read pending journal entries: {}", e),
+        }
         if cfg.autosync_startup() {
             tokio::select! {
                 sync_res = modpak.sync() => {

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -928,11 +928,7 @@ impl SysMinion {
 
     /// Send model completion ACK to master.
     async fn send_model_ack(self: &Arc<Self>, cycle_id: &str) {
-        let r = MinionMessage::new(
-            self.get_minion_id().to_string(),
-            RequestType::ModelAck,
-            json!({"cycle_id": cycle_id}),
-        );
+        let r = MinionMessage::new(self.get_minion_id().to_string(), RequestType::ModelAck, json!({"cycle_id": cycle_id}));
         match r.sendable() {
             Ok(msg) => self.request(msg).await,
             Err(e) => log::error!("Failed to send model ack: {e}"),

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -57,6 +57,7 @@ use libsysproto::{
         MinionQuery, SCHEME_COMMAND,
         commands::{CLUSTER_REBOOT, CLUSTER_REMOVE_MINION, CLUSTER_ROTATE, CLUSTER_SHUTDOWN, CLUSTER_SYNC, CLUSTER_TRAITS_UPDATE},
     },
+    replay::{ReplayIdentity, replay_identity_from_minion_bytes},
     rqtypes::{ProtoValue, RequestType},
     secure::{SecureDiagnosticCode, SecureFrame},
 };
@@ -967,11 +968,11 @@ impl SysMinion {
         let mut has_model_ack = false;
 
         for (_, payload) in entries {
-            if let Ok(msg) = serde_json::from_slice::<MinionMessage>(payload) {
-                match msg.req_type() {
-                    RequestType::ModelEvent => has_model_event = true,
-                    RequestType::ModelAck => has_model_ack = true,
-                    _ => {}
+            if let Ok(Some(identity)) = replay_identity_from_minion_bytes(payload) {
+                match identity {
+                    ReplayIdentity::ModelEvent { .. } => has_model_event = true,
+                    ReplayIdentity::ModelAck { .. } => has_model_ack = true,
+                    ReplayIdentity::Event { .. } => {}
                 }
             }
         }

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -996,6 +996,8 @@ impl SysMinion {
                 } else if let Err(e) = self.journal.mark_cycle_locally_complete(cycle_id) {
                     log::error!("Failed to mark cycle {} as locally complete: {}", cycle_id, e);
                 } else {
+                    // This is the durable local-completion boundary. After this point a hard
+                    // restart may replay delivery, but must not re-run the model locally.
                     log::info!("Marked cycle {} as locally complete after journaling ModelAck", cycle_id);
                 }
                 self.request(msg).await
@@ -1033,6 +1035,8 @@ impl SysMinion {
                             total_entries += 1;
                         }
                     }
+                    // Legacy journal entries may predate durable ModelAck journaling. Re-emit a
+                    // fresh ModelAck so master can still drive cycle cleanup with `CycleAck`.
                     if Self::pending_cycle_needs_model_ack(entries) {
                         self.send_model_ack(cycle_id).await;
                     }
@@ -1376,6 +1380,8 @@ pub(crate) async fn _minion_instance(cfg: MinionConfig, fingerprint: Option<Stri
                         if !cmd.cycle().is_empty() {
                             match m.journal.is_cycle_locally_complete(cmd.cycle()) {
                                 Ok(true) => {
+                                    // DPQ recovers unfinished scheduler state after restart. Once a cycle crossed
+                                    // the durable local-completion boundary, execution must not happen again here.
                                     log::info!("Skipping already-completed local cycle {}; replay recovery will finish delivery", cmd.cycle());
                                     return Ok(());
                                 }

--- a/sysminion/src/minion.rs
+++ b/sysminion/src/minion.rs
@@ -956,6 +956,10 @@ impl SysMinion {
             Ok(msg) => {
                 if let Err(e) = self.journal.append(cycle_id, &msg) {
                     log::error!("Failed to journal model ack for cycle {}: {}", cycle_id, e);
+                } else if let Err(e) = self.journal.mark_cycle_locally_complete(cycle_id) {
+                    log::error!("Failed to mark cycle {} as locally complete: {}", cycle_id, e);
+                } else {
+                    log::info!("Marked cycle {} as locally complete after journaling ModelAck", cycle_id);
                 }
                 self.request(msg).await
             }
@@ -1326,6 +1330,21 @@ pub(crate) async fn _minion_instance(cfg: MinionConfig, fingerprint: Option<Stri
                         while MODPAK_SYNC_STATE.is_syncing().await {
                             tokio::time::sleep(Duration::from_millis(200)).await;
                         }
+                        if !cmd.cycle().is_empty() {
+                            match m.journal.is_cycle_locally_complete(cmd.cycle()) {
+                                Ok(true) => {
+                                    log::info!("Skipping already-completed local cycle {}; replay recovery will finish delivery", cmd.cycle());
+                                    return Ok(());
+                                }
+                                Ok(false) => {
+                                    log::info!("Cycle {} has no durable local-completion marker; executing recovered job", cmd.cycle());
+                                }
+                                Err(err) => {
+                                    log::error!("Failed to inspect local completion state for cycle {}: {}", cmd.cycle(), err);
+                                }
+                            }
+                        }
+                        log::info!("Dispatching recovered or queued job for cycle {}", cmd.cycle());
                         m.clone().dispatch(cmd).await;
                         Ok(())
                     }


### PR DESCRIPTION
This PR intents to make `sysminion` and `sysmaster` survive hostile networks without losing results, duplicating local work, or corrupting master-side state.

- [x] Implementation
- [x] Documentation
- [x] Tests
